### PR TITLE
Fix matrix test diseases node slowness

### DIFF
--- a/pipelines/matrix/src/matrix/datasets/pair_generator.py
+++ b/pipelines/matrix/src/matrix/datasets/pair_generator.py
@@ -294,17 +294,17 @@ class MatrixTestDiseases(DrugDiseasePairGenerator):
         drugs_lst = graph.flags_to_ids(self._drug_axis_flags)
 
         # Generate all combinations
-        for idx, disease in tqdm(enumerate(test_diseases_lst)):
+        matrix_slices = []
+        for disease in tqdm(test_diseases_lst):
             matrix_slice = pd.DataFrame({"source": drugs_lst, "target": disease})
             test_pos_pairs_in_slice = test_pairs[test_pairs["target"].eq(disease)]
             test_pos_drugs_in_slice = test_pos_pairs_in_slice["source"]
             is_test_pos = matrix_slice["source"].isin(test_pos_drugs_in_slice)
             matrix_slice["y"] = is_test_pos.astype(int)
-            if idx == 0:
-                matrix = matrix_slice
-            else:
-                matrix = pd.concat([matrix, matrix_slice], ignore_index=True)
+            matrix_slices.append(matrix_slice)
 
+        # Concatenate all slices at once
+        matrix = pd.concat(matrix_slices, ignore_index=True)
         # Create a set of tuples from train_pairs for faster lookup
         train_pairs_set = set(zip(train_pairs["source"], train_pairs["target"]))
 


### PR DESCRIPTION
- add TQDM
- use set lookup to set runtime to O(1) instead of iterating over length of array every time
- fixes #153 