### PR TITLE
Update compose call due to removal of compose from worker

### DIFF
--- a/.github/workflows/run-pipeline.yml
+++ b/.github/workflows/run-pipeline.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Start docker-compose
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from matrix-pipeline
+          docker compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from matrix-pipeline
 
       - name: Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master
@@ -94,4 +94,4 @@ jobs:
       - name: Show logs
         if: failure()
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.test.yml logs
+          docker compose -f docker-compose.yml -f docker-compose.test.yml logs


### PR DESCRIPTION
Github/Ubuntu updated the defaults, no longer having `docker-compose` but `docker compose` 

https://github.com/orgs/community/discussions/116610
https://github.com/actions/runner-images/issues/9557

This fixes the CI