### PR TITLE
Small fix of CI to avoid intermittent network deletion issues

### DIFF
--- a/pipelines/matrix/Makefile
+++ b/pipelines/matrix/Makefile
@@ -47,6 +47,7 @@ docker_test: docker_build
 	IMG="$(dev_docker_image)" docker compose -f compose/docker-compose.yml \
 		-f compose/docker-compose.ci.yml \
 		up \
+		--force-recreate \
 		--abort-on-container-exit \
 		--exit-code-from matrix-pipeline
 


### PR DESCRIPTION
Sometimes docker networks are marked as already existing. This should avoid this from happening

https://github.com/docker/compose/issues/5745#issuecomment-370031631

```
GitHub Build Failed on Main branch! :rotating_light:
:female-technologist: Code URL: https://github.com/everycure-org/matrix/commit/e311bd6106c2297ae97b9c2104ff00599b45329c
:rocket: Action run link: https://github.com/everycure-org/matrix/actions/runs/10522657715
```