### PR TITLE
Ignore releases area for authors metadata in docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,7 +30,10 @@ plugins:
   - awesome-pages
   - search
   # - table-reader
-  - git-authors
+  - git-authors:
+     exclude:
+       - "releases/**"
+
   #- git-committers:
   #    repository: everycure-org/matrix
   #    branch: main


### PR DESCRIPTION
currently docs fails because of our authors plugin. It tries to generate authors for the blogs section but that works differently. disabling this section