### PR TITLE
Fixing CI pipeline missing unit tests that may fail on changes not related to python files

### DIFF
--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -76,9 +76,7 @@ jobs:
       - run: make venv
       - run: make install
       - run: make precommit
-      - run: make fast_test
       - run: make full_test
-        if: github.ref == 'refs/heads/main'
       - run: make compose_down # ensures containers & state are removed
       - run: make docker_test GIT_SHA=${GITHUB_SHA:0:7} #we overwrite the GIT_SHA in the Makefile
         # only if PR is labelled with "ready" or if branch is main

--- a/pipelines/matrix/conf/base/release/catalog.yml
+++ b/pipelines/matrix/conf/base/release/catalog.yml
@@ -31,16 +31,6 @@ release.prm.kg_edges:
       CALL apoc.create.relationship(subject, event.label, {kg_sources: event.kg_sources}, object) YIELD rel
       RETURN rel
 
-embeddings.prm.kg_edges:
-  <<: [*_neo4j_ds]
-  save_args:
-    # NOTE: The `match:Entity` ensures that the index we created above is leveraged
-    # while inserting edges, thereby speeding up the process massively.
-    query: > 
-      MATCH (subject:Entity {id: event.subject}), (object:Entity {id: event.object})
-      WITH subject, object, event
-      CALL apoc.create.relationship(subject, event.label, {kg_sources: event.kg_sources}, object) YIELD rel
-      RETURN rel
 
 release.prm.kg_embeddings:
   <<: [*_neo4j_ds]


### PR DESCRIPTION
we currently have a delta unit test approach in the PRs. This means we only ran unit tests that touch code that changed and skip the rest. But some unit tests also test the yaml files. And they may change, the tests do not get re-run and CI then fails on main. 
This now always runs the catalog naming convention checks on every PR. Makes CI a few seconds slower but avoids broken main branch. 