### PR TITLE
Add Documentation for GraphSage Comparison Experiment to Enhance Understanding of Topological Embeddings

### DIFF
--- a/docs/src/experiments/2024/ll-240816-E2E_Embeddings_Comparison.ipynb
+++ b/docs/src/experiments/2024/ll-240816-E2E_Embeddings_Comparison.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Comparison of Topological Embeddings\n",
+    "# Comparison of Topological Embeddings Before First E2E Run. \n",
     "\n",
     "Lee Lancashire\n",
     "\n",


### PR DESCRIPTION
Adding the Jupyter notebook comparing GraphSage embeddings from E2E run to the new docs section. 
