### PR TITLE
Update Test Configuration and Enhance NopTuner for Improved Model Tuning Performance

### DIFF
--- a/pipelines/matrix/conf/test/modelling/parameters/rf.yml
+++ b/pipelines/matrix/conf/test/modelling/parameters/rf.yml
@@ -1,5 +1,5 @@
 modelling.rf:
-    _overrides:
-      model_tuning_args:
-        tuner:
-          n_calls: 10
+  model_options:
+    model_tuning_args:
+      tuner:
+        n_calls: 10

--- a/pipelines/matrix/conf/test/modelling/parameters/xg_baseline.yml
+++ b/pipelines/matrix/conf/test/modelling/parameters/xg_baseline.yml
@@ -1,7 +1,4 @@
 modelling.xg_baseline:
-    _overrides:
-      generator:
-        n_unknown: 100
-      model_tuning_args:
-        tuner:
-          n_calls: 10
+  model_options:
+    generator:
+      n_unknown: 100

--- a/pipelines/matrix/conf/test/modelling/parameters/xg_ensemble.yml
+++ b/pipelines/matrix/conf/test/modelling/parameters/xg_ensemble.yml
@@ -1,5 +1,15 @@
 modelling.xg_ensemble:
-    _overrides:
-      model_tuning_args:
-        tuner:
-          n_calls: 10
+  model_options:
+    model_tuning_args:
+      tuner:
+        object: matrix.pipelines.modelling.tuning.NopTuner
+        estimator:
+          object: xgboost.XGBClassifier
+          random_state: ${globals:random_state}
+          tree_method: hist
+          n_jobs: 16
+          device: cpu # TODO: Add cuda
+      features: # Features use regex, source_0, source_1, .., target_0, target_1
+        - source_+
+        - target_+
+      target_col_name: y

--- a/pipelines/matrix/conf/test/modelling/parameters/xg_synth.yml
+++ b/pipelines/matrix/conf/test/modelling/parameters/xg_synth.yml
@@ -1,5 +1,15 @@
 modelling.xg_synth:
-    _overrides:
-      model_tuning_args:
-        tuner:
-          n_calls: 10
+  model_options:
+    model_tuning_args:
+      tuner:
+        object: matrix.pipelines.modelling.tuning.NopTuner
+        estimator:
+          object: xgboost.XGBClassifier
+          random_state: ${globals:random_state}
+          tree_method: hist
+          n_jobs: 16
+          device: cpu # TODO: Add cuda
+      features: # Features use regex, source_0, source_1, .., target_0, target_1
+        - source_+
+        - target_+
+      target_col_name: y

--- a/pipelines/matrix/src/matrix/pipelines/modelling/tuning.py
+++ b/pipelines/matrix/src/matrix/pipelines/modelling/tuning.py
@@ -21,11 +21,13 @@ class NopTuner(BaseEstimator, MetaEstimatorMixin):
     yields the sklearn compatible estimator as provided during initialization.
     """
 
-    def __init__(self, estimator: BaseEstimator):
+    def __init__(self, estimator: BaseEstimator, **kwargs):
         """Initialize the tuner.
 
         Args:
             estimator: sklearn compatible Estimator to tune.
+            **kwargs: Convenience argument that allows to pass unused parameters
+                to the estimator.
         """
         self._estimator = estimator
         super().__init__()


### PR DESCRIPTION
# Description

An update to the modelling config for the test environment. This modification ensures that hyperparameter optimisation is performed for only one model configuration (`rf`).

This cuts run-time of the test pipeline by about 3 times, while still ensuring we test the successful completion of the hyper-parameter optimisation functionality.

# How Has This Been Tested?

On my local machine the pipeline successfully finished in 56 seconds (vs. 3 min 7 seconds previously). 


# Checklist:

- [ ] added label to PR (e.g. `enhancement` or `bug`)
- [ ] I have looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] ran `/run-tests` check at the end of PR collaboration work to execute integration tests

