### PR TITLE
Update local-setup.md

### DIFF
--- a/docs/src/onboarding/local-setup.md
+++ b/docs/src/onboarding/local-setup.md
@@ -21,6 +21,15 @@ This command executes a number of make targets, namely:
 
 Generally, the `Makefile` is a good place to start to get a sense of how our codebase is structured. 
 
+If you attempted to build this software locally with Python 3.12, it will fail due to the removal of distutils from Python after version 3.11. To fix this, remove the directory ".venv" from `pipelines/matrix` and set the python version to 3.11:
+
+```
+pyenv install 3.11
+pyenv global 3.11
+```
+
+then run `make` again.
+
 <div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;"><iframe src="https://us06web.zoom.us/clips/embed/ghxELqxMExaMh96j_58dMq8UnXaXEcEtSTRVxXf7zXNd5l4OSgdvC5xwANUE1ydp7afd-M42UkQNe_eUJQkCrXIZ.SAPUAWjHFb-sh7Pj" frameborder="0" allowfullscreen="allowfullscreen" style="position: absolute; width: 100%; height: 100%; top: 0; left: 0; "></iframe></div>
 
 ### Docker compose for local execution


### PR DESCRIPTION
add details on attempting to install when python 3.12 is default.

# Description
This modification to the docs addresses an issue I encountered with locally building the matrix pipeline. If you attempt to make with python 3.12 as the default, the build will fail because of a deprecated package distutils which was removed as of version 3.12. the .venv directory needs to be removed from the pipelines/matrix folder and the global python version currently needs to be set to 3.11 in order to resolve the issue. 

# How Has This Been Tested?
I was previously unable to make the software due to this issue and this change resolved that issue.

# Checklist:

- [ x] added label to PR (e.g. `enhancement` or `bug`)
- [ x] I have looked at the diff on github to make sure no unwanted files have been committed. 
- [ x] I have made corresponding changes to the documentation
- [na] I have added tests that prove my fix is effective or that my feature works
- [na] Any dependent changes have been merged and published in downstream modules
- [na] ran `/run-tests` check at the end of PR collaboration work to execute integration tests

