### PR TITLE
Update Common Errors Documentation to Address Python 3.12 Build Issues

### DIFF
--- a/docs/src/contribute/common_errors.md
+++ b/docs/src/contribute/common_errors.md
@@ -5,6 +5,32 @@
     that come after us debug issues we solved before. We need this because some errors appear when trying something else and that is not codified because we codify _what works_ not what we tried to get to this working state. However, reoccuring errors often occur in software engineering and experienced project members regularly help by "giving the solution" to the error that "they have seen before". This page seeks to collect those errors.
 
 
+## Attempting to build local instance of matrix pipeline with Python 3.12
+
+If you attempted to build the matrix pipeline locally with Python 3.12, it will fail due to the removal of distutils from Python after version 3.11. you may get a message that looks somewhat like the following:
+
+```
+error: Failed to prepare distributions
+  Caused by: Failed to fetch wheel: numpy==1.23.5
+  Caused by: Build backend failed to determine extra requires with `build_wheel()` with exit status: 1
+
+...
+
+ModuleNotFoundError: No module named 'distutils'
+```
+
+
+
+To fix this, remove the directory ".venv" from `pipelines/matrix` and set the python version to 3.11:
+
+```
+rm -r .venv
+pyenv install 3.11
+pyenv global 3.11
+```
+
+then `make` again.
+
 
 ## Module not found in python
 ```


### PR DESCRIPTION
Explains error encountered when attempting to build local instance of matrix pipeline with Python 3.12 and how to fix.

# Description

helps to solve problem building local instance of matrix pipeline when python3.12 is set as default.

# How Has This Been Tested?

fixed an issue I had with installation.


# Checklist:

- [ x] added label to PR (e.g. `enhancement` or `bug`)
- [x ] I have looked at the diff on github to make sure no unwanted files have been committed. 
- [ x] I have made corresponding changes to the documentation
- [na ] I have added tests that prove my fix is effective or that my feature works
- [na ] Any dependent changes have been merged and published in downstream modules
- [ na] ran `/run-tests` check at the end of PR collaboration work to execute integration tests

