### PR TITLE
Clarify Python 3.11 Requirement in Installation Guide to Prevent Compatibility Issues

### DIFF
--- a/docs/src/onboarding/installation.md
+++ b/docs/src/onboarding/installation.md
@@ -31,6 +31,8 @@ We leverage [`uv`](https://github.com/astral-sh/uv) to manage/install our Python
 requirements. Note that while many may be used to Conda, UV and Conda cannot be used in parallel. Using Conda is hence at your own risk.
 
 
+Python 3.11 is currently **required** to build the matrix pipeline. If you attempt to use Python 3.12, you will likely encounter errors with the recently-removed `distutils` package (see the common errors document for how to solve this) 
+
 Install as follows, then create a virtual env and install the requirements:
 
 


### PR DESCRIPTION
clarify that Python 3.11 is required (3.12 may not work for the install)

# Description

I encountered an issue using 3.12 for installation -- added clarification that 3.11 is currently required.

# How Has This Been Tested?

Using Python 3.11 fixed the problem that I encountered

# Checklist:

- [ x] added label to PR (e.g. `enhancement` or `bug`)
- [ x] I have looked at the diff on github to make sure no unwanted files have been committed. 
- [ x] I have made corresponding changes to the documentation
- [ na] I have added tests that prove my fix is effective or that my feature works
- [ na] Any dependent changes have been merged and published in downstream modules
- [ na] ran `/run-tests` check at the end of PR collaboration work to execute integration tests

