### PR TITLE
Add 'make clean' Target to Makefile for Improved Cache Management

### DIFF
--- a/pipelines/matrix/Makefile
+++ b/pipelines/matrix/Makefile
@@ -89,6 +89,8 @@ licenses_container: docker_build
 		image --scanners license --severity UNKNOWN,CRITICAL $(dev_docker_image)
 
 clean:
-        rm -rf .pytest_cache .venv
-        rm -rf ~/.cache/uv ~/.cache/pre-commit
-        docker volume prune
+	@echo "cleaning various cache locations to ensure clean installation is possible"
+	@echo "this may be necessary e.g. when updating one of our local packages"
+	rm -rf .pytest_cache .venv
+	rm -rf $(uv cache dir) ~/.cache/pre-commit
+	docker volume prune -f


### PR DESCRIPTION
add make clean 

may want to add some conditional statement for uv since cache is located in different places depending on OS, e.g. (not sure if correct):

if [[ "$OSTYPE" == "linux-gnu"* ]]; then
        rm -rf $XDG_CACHE_HOME/uv
elif [[ "$OSTYPE" == "darwin"* ]]; then
        rm -rf $HOME/.cache/uv
elif [[ "$OSTYPE" == "win32" ]]; then
        rd /s /q %LOCALAPPDATA%\uv\cache
else
        # Unknown.
fi



# Description

Add make clean option to makefile in order to get rid of cached packages in UV. This stems from the issues we encountered when trying to build the pipeline with python3.12.

Would love to hear others' input if this is useful or if you want more things to be removed when make clean is run.

# How Has This Been Tested?

I used this make clean function to remove 

# Checklist:

- [ x] added label to PR (e.g. `enhancement` or `bug`)
- [ x] I have looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] ran `/run-tests` check at the end of PR collaboration work to execute integration tests

