### PR TITLE
Add WSL Installation Instructions for git-crypt in Onboarding Documentation

### DIFF
--- a/docs/src/onboarding/git-crypt.md
+++ b/docs/src/onboarding/git-crypt.md
@@ -7,10 +7,19 @@ without actually exposing the data itself because a decryption key is required.
 
 ## Required installations
 
-```bash
-brew install git-crypt
-brew install gpg
-```
+=== "MacOS"
+
+    ```bash
+    brew install git-crypt
+    brew install gpg
+    ```
+
+=== "Windows (WSL)"
+
+    ```bash
+    sudo apt-get update
+    sudo apt-get install git-crypt
+    ```
 
 ## Joining as a new user
 
@@ -97,7 +106,7 @@ Next run the following command
 
 ```
 # alternatively, you can pass in the ID of the key which looks like this 637334785B9F74A364C14FC5A1C5DB60575ED571
-gpg --armor --export <used@email.com>
+gpg --armor --export used@email.com
 ```
 
 The command should return something like 


### PR DESCRIPTION
Added WSL for Windows instructions to install git-crypt and gpg

# Description

Added WSL instructions to install git-crypt and gpg

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Checked with Pascal that installation worked on WSL

# Checklist:

- [x] added label to PR (e.g. `enhancement` or `bug`)
- [x] I have looked at the diff on github to make sure no unwanted files have been committed. 
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] ran `/run-tests` check at the end of PR collaboration work to execute integration tests

