### PR TITLE
Add `-a` option to `git-crypt lock` command for enhanced functionality

### DIFF
--- a/docs/src/onboarding/git-crypt.md
+++ b/docs/src/onboarding/git-crypt.md
@@ -148,7 +148,7 @@ git-crypt unlock
 Re-enter the passphrase you used to create the public key to unlock. 
 
 You can lock the key by running 
-```git-crypt lock``` 
+```git-crypt lock -a``` 
 
 ## General setup
 


### PR DESCRIPTION
# Description

When I tried `git-crypt lock` it did not work on my local build. When `git-crypt lock -a` it did the work to lock the key file `conf/local/service-account.json`. 

# How Has This Been Tested?

No test written. Just tried on local build. 


# Checklist:

- [x] added label to PR (e.g. `enhancement` or `bug`)
- [x] I have looked at the diff on github to make sure no unwanted files have been committed. 
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] ran `/run-tests` check at the end of PR collaboration work to execute integration tests

