### PR TITLE
Add malanjary as a new git-crypt collaborator for secure code collaboration

### DIFF
--- a/.git-crypt/keys/HUB/0/1770219BD68B66BDA2AFAD9601E5AFBA1030BF3E.gpg
+++ b/.git-crypt/keys/HUB/0/1770219BD68B66BDA2AFAD9601E5AFBA1030BF3E.gpg
@@ -1,0 +1,1 @@
+„^§f5Oš4”@¿a_‹}ýS4ªWç”è4»A§r•š¬‘9L|zTj)0˜az‚¢&_¾œ–'WÂ¬vT£\¸Õ·?Z«;åŸk.2ÿòo¯â2¤	ÔÀ	ü¾lq‡Å·'ŠÓ§¡ÃU(ôç”ÆG±ôÒhãB³@³d„*#1‹J¹‘þ(iq'D"i‘Äö®^7‡dóIïdh‡˜!TìB‹ª%â¹ÃbXNkŸÞPáÞDê„d›Ø;¼÷~]ÕxEJN„M„dÙ‡p»k»JûÇ_,Ò¦9èÆËPÂ`Í„¨~Ké/M3žàˆ-¹	/±Ø­k»½ö¦¡³?îŠƒq´ˆ–ß€tÏó°œüTžX²‘Ò1Äp¡0Uß{\æ2|¦


### PR DESCRIPTION
New collaborators:

	1030BF3E malanjary <malanjary@scripps.edu>
