### PR TITLE
Revert Push Image Workflow to Self-Hosted Environment for CI Stability

### DIFF
--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -120,7 +120,7 @@ jobs:
   push_image:
     needs: [ci]
     if: github.ref == 'refs/heads/main'
-    runs-on: 'ubuntu-latest' # 'self-hosted'
+    runs-on: 'self-hosted'
     environment: dev
     permissions: write-all
     defaults:


### PR DESCRIPTION
# Description

In #450 we switched to GitHub-hosted workflows. This works fine for some CIs but is not suitable for `push_image` workflow which is seems to be specific to the self-hosted container. Need to revert that change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] ...

# Checklist:

- [ ] added label to PR (e.g. `enhancement` or `bug`)
- [ ] I have looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] ran `/run-tests` check at the end of PR collaboration work to execute integration tests

