### PR TITLE
Add Kevin Schaper as a git-crypt collaborator for secure code collaboration

### DIFF
--- a/.git-crypt/keys/HUB/0/9083EF213DD1F9371948B62BCFCD5386C96E3B2D.gpg
+++ b/.git-crypt/keys/HUB/0/9083EF213DD1F9371948B62BCFCD5386C96E3B2D.gpg
@@ -1,0 +1,1 @@
+„^µv/;C}@F‚åªfVüí?u¯—ÛØ…®ý³#veFÒ[Oî,Ã1U02pÌsï´ƒ¯µÐ÷úg^V÷(’®ê÷úŒºŒŠ)?ýÂ›*¸+É/5K×2ÀhÑcÔÀ	µ!p!	ã1R°“ëÆ2jÓfwm-ÉA÷¨êj/uì?ƒ±ˆ)+:4>Êòžvð¾')®îI*Ô“_!ü¸ÉäÅÜÁãK§¡â§LÞI};Q0´¦Tûe²Q[ È?Í/ u¶Q¡’T:¥`[™úgl‘Q´©y~ˆŒkpµÞÃÁóRkòÝ5ØÜ¼¬³§•C¢¥%ò·ñA¾V:òþµ&9¤†q«z#Õ„•–;Lð œŸ{ÏÆ^Ó hùìTþ!ç²§^Ê²C


### PR DESCRIPTION
New collaborators:

	C96E3B2D Kevin Schaper <kevin@tislab.org>
