### PR TITLE
Fix Docker Service Conflict by Adding --remove-orphans Flag in Compose Up Command

### DIFF
--- a/pipelines/matrix/Makefile
+++ b/pipelines/matrix/Makefile
@@ -68,7 +68,7 @@ docker_push: docker_build
 	docker push $(dev_docker_image):${TAG}
 
 compose_up:
-	docker compose -f compose/docker-compose.yml up -d --wait
+	docker compose -f compose/docker-compose.yml up -d --wait --remove-orphans
 
 compose_down:
 	bash scripts/compose_down_retry.sh


### PR DESCRIPTION
We renamed a docker-compose container and this causes docker-compose to error out on people's instances. adding a flag cleans up orphan containers so people aren't impacted