### PR TITLE
Fix MLFlow Run Name Handling to Allow Null Values for Improved Flexibility

### DIFF
--- a/pipelines/matrix/conf/base/mlflow.yml
+++ b/pipelines/matrix/conf/base/mlflow.yml
@@ -39,7 +39,7 @@ tracking:
 
   run:
     id: null # if `id` is None, a new run will be created
-    name: null
+    name: ${oc.env:RUN_NAME, null, True} # if `name` is None, pipeline name will be used for the run name. You can use "${km.random_name:}" to generate a random name (mlflow's default)
     nested: True  # if `nested` is False, you won't be able to launch sub-runs inside your nodes
   params:
     dict_params:

--- a/pipelines/matrix/src/matrix/resolvers.py
+++ b/pipelines/matrix/src/matrix/resolvers.py
@@ -28,7 +28,7 @@ def merge_dicts(dict1: Dict, dict2: Dict) -> Dict:
     return result
 
 
-def env(key: str, default: str = None) -> Optional[str]:
+def env(key: str, default: str = None, allow_null: str = False) -> Optional[str]:
     """Load a variable from the environment.
 
     See https://omegaconf.readthedocs.io/en/latest/custom_resolvers.html#custom-resolvers
@@ -36,13 +36,13 @@ def env(key: str, default: str = None) -> Optional[str]:
     Args:
         key (str): Key to load.
         default (str): Default value to use instead
-
+        allow_null (bool): Bool indicating whether null is allowed
     Returns:
         str: Value of the key
     """
     try:
         value = os.environ.get(key, default)
-        if value is None:
+        if value is None and not allow_null:
             raise KeyError()
         return value
     except KeyError:


### PR DESCRIPTION
MLFlow has been configured to use a stable run name in our cloud environment, enabling distributed execution across the cluster.

In one of our PRs. we accidentally introduced a stable name for the base environment, thereby resulting in local dev runs writing to the same MLFlow run, giving duplicate errors as a result. 

This PR ensures we don't use a stable run name in test. 

> The run name is only picked up when it's explicitly set in the .env file. This is when we want to use the --from-env functionality to run certain nodes against `cloud`.