### PR TITLE
Allow docker platform to be set, defaulting to linux/amd64

### DIFF
--- a/pipelines/matrix/compose/docker-compose.yml
+++ b/pipelines/matrix/compose/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # note this works only on MacOS devices (or other ARM chipsets), check
     # `docker-compose.test.yml` for the override
     image: neo4j:5.21.0-enterprise
-    # platform: ${DOCKER_PLATFORM:-linux/arm64}
+    platform: ${DOCKER_PLATFORM:-linux/amd64}
     restart: unless-stopped
     ports:
       - 7474:7474
@@ -56,7 +56,7 @@ services:
   # This is used for local development and integration testing
   mockserver:
     image: mockserver/mockserver
-    # platform: ${DOCKER_PLATFORM:-linux/arm64}
+#    platform: ${DOCKER_PLATFORM:-linux/arm64}
     container_name: mockserver
     restart: unless-stopped
     user: root


### PR DESCRIPTION
I uncommented the setting of DOCKER_PLATFORM for neo4j in the docker-compose.yml, and changed the default to linux/amd64. This was enough that I can now run the pipeline successfully locally with

```
TARGET_PLATFORM=linux/arm64 DOCKER_PLATFORM=linux/arm64 make
```
