### PR TITLE
Standardize Makefile targets to use venv and improve cross-platform compatibility


### DIFF
--- a/pipelines/matrix/Makefile
+++ b/pipelines/matrix/Makefile
@@ -5,22 +5,19 @@ export PYSPARK_PYTHON = .venv/bin/python
 export UV_PYTHON = .venv/bin/python
 export TQDM_DISABLE ?= 1
 TARGET_PLATFORM ?= linux/amd64
+PREREQUISITES := docker gcloud python3 java uv
 
 # ensures all make targets run in one shell (rather than line by line in new shell)
 .ONESHELL: 
-
 
 default: install fast_test compose_down integration_test
 	echo "done!"
 
 prerequisites:
-	@command -v docker >/dev/null 2>&1 || { echo "Error: docker is not installed." >&2; exit 1; }
-	@command -v gcloud >/dev/null 2>&1 || { echo "Error: gcloud is not installed." >&2; exit 1; }
-	@command -v python3 >/dev/null 2>&1 || { echo "Error: python3 is not installed." >&2; exit 1; }
-	@command -v java >/dev/null 2>&1 || { echo "Error: java is not installed." >&2; exit 1; }
-	@command -v uv >/dev/null 2>&1 || { echo "Error: uv is not installed." >&2; exit 1; }
-	@echo "All prerequisites are installed."
-
+	$(info Checking if prerequisites are installed...)
+	$(foreach exec,$(PREREQUISITES),\
+        $(if $(shell command -v $(exec) 2>/dev/null),,$(error "$(exec) is not installed.")))
+	$(info All prerequisites are installed.)
 
 venv: prerequisites
 	if [ ! -d .venv ]; then uv venv -p 3.11; fi
@@ -29,10 +26,9 @@ venv: prerequisites
 install: venv precommit-hooks
 	uv pip install -r requirements.txt #force it to install in our venv
 
-
 precommit: precommit-hooks
 	git fetch origin
-	uv run pre-commit run -s origin/main -o HEAD
+	uv run pre-commit run --from-ref origin/main --to-ref HEAD
 
 precommit-hooks:
 	uv pip install pre-commit 
@@ -97,39 +93,44 @@ licenses_container: docker_build
 clean:
 	@echo "cleaning various cache locations to ensure clean installation is possible"
 	@echo "this may be necessary e.g. when updating one of our local packages"
+	uv run pre-commit clean
 	rm -rf .pytest_cache .venv
-	rm -rf $(uv cache dir) ~/.cache/pre-commit
+	uv cache clean
 	docker volume prune -f
 
 diagnostics:
 	echo "Collecting system diagnostics..."
-	echo "1. Operating System:"
+	echo "Operating System:"
 	-uname -a
-	echo "\n2. System Information:"
-	-python -c "import platform; print(platform.uname())"
-	echo "\n3. Python Version:"
-	-python3 --version || echo "Python is not installed."
-	echo "\n4. Installed Python Packages:"
-	-pip freeze || echo "pip is not installed or no packages found."
-	echo "\n5. Environment Variables (related to Python):"
-	-printenv | grep PYTHON || echo "No Python-related environment variables found."
-	echo "\n6. Memory & CPU Usage:"
-	-python -c "import psutil; print(psutil.virtual_memory(), psutil.cpu_percent())" || echo "psutil is not installed."
-	echo "\n7. Check Virtual Environment (if applicable):"
-	-which python || echo "Python is not in PATH."
-	echo "\n8. Docker Version:"
+	echo "\nDocker Version:"
 	-docker --version || echo "Docker is not installed."
-	echo "\n9. Docker Disk Usage:"
+	echo "\nDocker Disk Usage:"
 	-docker system df || echo "Docker is not installed or not running."
-	echo "\n10. Docker Memory and CPU Usage:"
+	echo "\nDocker Memory and CPU Usage:"
 	-docker stats --no-stream || echo "Docker is not installed or not running."
-	echo "\n11. GCloud Version:"
+	echo "\nGCloud Version:"
 	-gcloud --version || echo "GCloud is not installed."
-	echo "\n12. Java Version:"
+	echo "\nJava Version:"
 	-java -version || echo "Java is not installed."
-	echo "\n13. UV Version:"
+	echo "\nUV Version:"
 	-uv --version || echo "UV is not installed."
-	echo "\n14. Disk Space:"
+	echo "\nCheck Virtual Environment (if applicable):"
+	-uv run which python || echo "Python is not in PATH."
+	echo "\nPython Version:"
+	-uv run python3 --version || echo "Python is not installed."
+	echo "\nSystem Information:"
+	-uv run python -c "import platform; print(platform.uname())"
+	echo "\nInstalled Python Packages:"
+	-uv run pip freeze || echo "pip is not installed or no packages found."
+	echo "\nEnvironment Variables (related to Python):"
+	-uv run printenv | grep PYTHON || echo "No Python-related environment variables found."
+	echo "\nMemory & CPU Usage:"
+	-uv run python -c "import psutil; print(psutil.virtual_memory(), psutil.cpu_percent())" || echo "psutil is not installed."
+	echo "\nJAVA_HOME"
+	-printenv JAVA_HOME
+	echo "\nSPARK_HOME"
+	-printenv SPARK_HOME
+	echo "\nDisk Space:"
 	-df -h
 	echo "\nDiagnostics complete."
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

1. Rather than repeating the same code for checking which executables
   are present, it's more desirable to have this in a loop, so messages
   can be altered for all and new tools are added more easily to the
   check.
2. I tend to prefer the long-form of command arguments if they're not
   overly well-known, especially in scripts to aid with lookup, so I've
   extended a few command arguments.
3. Rather than assuming the location where some tools, like pre-commit,
   manage their internals, it's typically better to use the dedicated
   commands of said tools to cleanup any caches. Of course, if at that
   time the tool is not available (e.g. not activated the venv that
   contains these tools), then such folders can't be removed this way.
   However, since we're using `uv`, it's safe to assume that people have
   done the initial setup (i.e. `make install`).
4. I've added two variables to the diagnostics that -in my experience-
   are often illuminating for problems, especially with Spark.
   Additionally, I felt the order of the diagnostics needed some changes
   and was then annoyed by the manual numbering, which doesn't really
   add any value, so I've removed those and shuffled things around.
   After all, it doesn't make much sense to try to run a uv command
   if it isn't installed.


## Fixes / Resolves the following issues:

- No known issues yet, but both `pre-commit` and `uv` can have their cache located in non-default locations, so now both get cleared through their dedicated APIs.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensure the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] looked at the diff on github to make sure no unwanted files have been committed. 
