### PR TITLE
Remove contractor name from repo

### DIFF
--- a/infra/argo/app-of-apps/templates/data-release.yml
+++ b/infra/argo/app-of-apps/templates/data-release.yml
@@ -11,7 +11,7 @@ spec:
   source:
     path: {{ .Values.spec.source.repoPath }}/data-release
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: argo-quickstart-dataminded # {{ .Values.spec.source.devTargetRevision }}
+    targetRevision: data-release-quickstart  # {{ .Values.spec.source.devTargetRevision }}
   syncPolicy:
     syncOptions:     # Sync options which modifies sync behavior
     - CreateNamespace=true # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.


### PR DESCRIPTION
# Description of the changes <!-- required! -->

We've removed the name of the contractor from several places in the code. Note that it's not really purged, for which git history would need to be rewritten, which might cause headaches for our colleagues. However, since there's also a plan to purge history for v1.0.0 related to some libraries, perhaps we shouldn't be concerned here either?

The newly referenced branch is already pushed.


## Fixes / Resolves the following issues:

- Contractor name clearly visible


