### PR TITLE
Extend engineering permissions

### DIFF
--- a/infra/deployments/hub/dev/iam.tf
+++ b/infra/deployments/hub/dev/iam.tf
@@ -15,7 +15,7 @@ module "project_iam_bindings" {
 
   bindings = {
     "roles/bigquery.studioAdmin"      = local.tech_team_group
-    "roles/notebooks.developer"       = local.tech_team_group
+    "roles/notebooks.admin"           = local.tech_team_group
     "roles/ml.admin"                  = local.tech_team_group
     "roles/aiplatform.admin"          = local.tech_team_group
     "roles/artifactregistry.writer"   = local.tech_team_group


### PR DESCRIPTION
# Description of the changes <!-- required! -->

This PR adds more extensive IAM permissions for the tech team.

See reference for all roles: https://cloud.google.com/iam/docs/understanding-roles#bigquery-roles

Following roles are being added for `local.tech_team_group`:


**roles/bigquery.studioAdmin**
Combination role of BigQuery Admin, Dataform Admin, and Notebook Runtime Admin.


**roles/notebooks.admin**
Full access to Notebooks, all resources.


**roles/storage.objectUser**
Access to create, read, update and delete objects and multipart uploads in GCS. 

**roles/ml.admin**
Provides full access to AI Platform resources, and its jobs, operations, models, and versions.


**roles/aiplatform.admin**
Grants full access to all resources in Vertex AI


**roles/compute.admin**
Full control of all Compute Engine resources.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensure the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] looked at the diff on github to make sure no unwanted files have been committed. 
- [x] made corresponding changes to the documentation
- [x] added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people


<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
