### PR TITLE
adds the argo-events infra in its own app

### DIFF
--- a/infra/argo/app-of-apps/templates/argo-events.yaml
+++ b/infra/argo/app-of-apps/templates/argo-events.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-events
+  namespace: argo-events
+spec:
+  destination:
+    namespace: argo-events
+    server: {{ .Values.spec.destination.server }}
+  project: default
+  source:
+    path: {{ .Values.spec.source.repoPath }}/argo-events
+    repoURL: {{ .Values.spec.source.repoURL }}
+    targetRevision: {{ .Values.spec.source.devTargetRevision }}
+  syncPolicy:
+    syncOptions:     # Sync options which modifies sync behavior
+    - CreateNamespace=true # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
+    automated:
+      prune: true


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

Installing argo-events as a dependency in a different app (data-release) gets deployed correctly by argocd (all green), no error message is produced, but the argo-events infra (most importantly the EventBus) is not actually deployed, its pods are not being created and it is not found by the sensor.

This PR tests the Hypothesis - it is impossible to install argo-events in a namespace other than "argo-events".
Reproducing this locally in a kind cluster, I do get errors when installing it to a custom namespace:

```
helm install my-release argo/argo-events -n testing-argo-events --create-namespace 
      
Error: INSTALLATION FAILED: Unable to continue with install: 
CustomResourceDefinition "eventbus.argoproj.io" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; 
annotation validation error: key "meta.helm.sh/release-name" must equal "my-release": current value is "argo-events"; 
annotation validation error: key "meta.helm.sh/release-namespace" must equal "testing-argo-events": current value is "argo-events"
```

But when installing it into the namespace "argo-events" it works fine:

```
helm install argo-events argo/argo-events -n argo-events --create-namespace
NAME: argo-events
LAST DEPLOYED: Thu Nov 28 19:54:53 2024
NAMESPACE: argo-events
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensure the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] made corresponding changes to the documentation
- [ ] added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people


<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
