### PR TITLE
add pipeline and release labels to the workflow template

### DIFF
--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -10,6 +10,8 @@ spec:
       run: {% raw %}'{{ workflow.parameters.run_name }}'
       {% endraw %}
       username: "{{ username }}"
+      pipeline_name: "{{ pipeline_name }}"
+      release_version: "{{ release_version }}"
   entrypoint: "pipeline"
   arguments:
     parameters:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This PR introduces two new labels into the workflow template.

In order to trigger the follow up workflow, which takes care of the data release, we must determine when to do so. Currently the workflow itself is not aware of the pipeline it is running, this value is only passed into its container. By adding the pipeline label onto the workflow, I can filter on workflow completion events using this label in the Sensor.

The information about the release version must be saved in a similar fashion in the workflow metadata via a label, so that it can be passed on into the github action.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensure the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] made corresponding changes to the documentation
- [ ] added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people


<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
