### PR TITLE
Add ai platform user role to github actions rw service account

### DIFF
--- a/infra/deployments/hub/dev/iam.tf
+++ b/infra/deployments/hub/dev/iam.tf
@@ -3,7 +3,7 @@ locals {
 
   matrix_viewers_group              = [local.matrix_all_group, "group:matrix-viewers@everycure.org"]
   tech_team_group                   = ["group:techteam@everycure.org", "group:ext.tech.dataminded@everycure.org"]
-  github_actions_rw_service_account = ["sa-github-actions-rw@mtrx-hub-dev-3of.iam.gserviceaccount.com"]
+  github_actions_rw_service_account = ["serviceAccount:sa-github-actions-rw@mtrx-hub-dev-3of.iam.gserviceaccount.com"]
 }
 
 module "project_iam_bindings" {


### PR DESCRIPTION
# Description of the changes 

Add `aiplatform.user` role to service account `sa-github-actions-rw@mtrx-hub-dev-3of.iam.gserviceaccount.com`

## Fixes / Resolves the following issues:

The GitHub Actions runner can't call the Gemini API to generate release notes and articles. Likely because the service account`sa-github-actions-rw@mtrx-hub-dev-3of.iam.gserviceaccount.com` does not have the role as `aiplatform.user`


# Checklist:

- [x] added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensure the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] made corresponding changes to the documentation
- [ ] added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people


<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
