### PR TITLE
Big memory /cost optimized nodes 

### DIFF
--- a/infra/modules/stacks/compute_cluster/gke.tf
+++ b/infra/modules/stacks/compute_cluster/gke.tf
@@ -24,6 +24,7 @@ locals {
     min_count          = 0
     max_count          = 5
     local_ssd_count    = 0
+    disk_type          = "pd-ssd"
     disk_size_gb       = 400
     enable_gcfs        = true
     enable_gvnic       = true
@@ -39,6 +40,7 @@ locals {
     min_count          = 0
     max_count          = 20
     local_ssd_count    = 0
+    disk_type          = size > 32 ? "pd-ssd" : "pd-standard"
     disk_size_gb       = 200
     enable_gcfs        = true
     enable_gvnic       = true


### PR DESCRIPTION
Noticed we're using generic non memory optimized nodes for the neo4j steps that ask for 192GB of ram. 

- unsure if we need that much memory @matwasilewski can you check the utilization of memory for pod `release-v0-2-5-66cc1465-neo4j-3490963879` which is the biggest memory node we have overall (robokop+rtx loading everything into neo4j) using https://grafana.platform.dev.everycure.org

