### PR TITLE
Roles modification to test Gemini call

### DIFF
--- a/infra/deployments/hub/dev/iam.tf
+++ b/infra/deployments/hub/dev/iam.tf
@@ -3,7 +3,7 @@ locals {
 
   matrix_viewers_group = [local.matrix_all_group, "group:matrix-viewers@everycure.org"]
   tech_team_group      = ["group:techteam@everycure.org", "group:ext.tech.dataminded@everycure.org"]
-
+  everycure_group      = ["group:techteam@everycure.org"]
 }
 
 module "project_iam_bindings" {
@@ -16,6 +16,8 @@ module "project_iam_bindings" {
   bindings = {
     "roles/bigquery.studioAdmin"           = local.tech_team_group
     "roles/notebooks.admin"                = local.tech_team_group
+    "roles/ml.admin"                       = local.everycure_group
+    "roles/aiplatform.admin"               = local.everycure_group
     "roles/ml.developer"                   = local.tech_team_group
     "roles/artifactregistry.writer"        = local.tech_team_group
     "roles/storage.objectCreator"          = local.tech_team_group


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Removed `ml.admin` and `aiplatform.admin`, added `ml.developer `role to test gemini call from my own machine. Because I suspect the added `ml.developer` role (there's no `aiplatform.developer`) to GitHub sa is still not sufficient to call Gemini API. Maybe the GitHub sa still needs `aiplatform.user` role.  ([link to roles reference](https://cloud.google.com/iam/docs/understanding-roles))

All the changes will be restored once the lacking permission is found out. 



## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensure the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] made corresponding changes to the documentation
- [ ] added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people


<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
