### PR TITLE
Correct Argo node's output to match the single item returned by its function

### DIFF
--- a/pipelines/matrix/src/matrix/pipelines/data_release/pipeline.py
+++ b/pipelines/matrix/src/matrix/pipelines/data_release/pipeline.py
@@ -13,7 +13,7 @@ from matrix.pipelines.embeddings.nodes import ingest_edges, ingest_nodes
 last_node = ArgoNode(
     func=lambda x, y, z: True,
     inputs=["data_release.prm.kg_edges", "data_release.prm.kgx_edges", "data_release.prm.kgx_nodes"],
-    outputs=["data_release.dummy"],
+    outputs="data_release.dummy",
     name=last_node_name,
 )
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

This PR relates to the PRs that aim to get the automatic data versioning out. This PR changes the output of the Kedro Node that represents the last node of the release pipeline, to reflect that there is a single output, rather than multiple. As documented in the [Kedro docs](https://docs.kedro.org/en/stable/nodes_and_pipelines/nodes.html#syntax-for-output-variables), a single output should not use a list for the node's output variable.


## Fixes / Resolves the following issues:

- Breaks the current release flow.
