### PR TITLE
Add label hide-from-release to Release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -114,4 +114,5 @@ jobs:
           --base main \
           --body "Adds the release article and associated notes" \
           --draft \
-          --label Release
+          --label Release \
+          --label hide-from-release


### PR DESCRIPTION
# Description of the changes <!-- required! -->

When the GitHub Actions bot creates a release PR automatically, there should be two labels: `Release `and `hide-from-release`.
Added the missing `hide-from-release`.


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] made corresponding changes to the documentation
- [ ] added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people


<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
