### PR TITLE
Feat: Add --headless flag to CLI to disable interactions in e.g. CI.

### DIFF
--- a/pipelines/matrix/src/matrix/cli_commands/submit.py
+++ b/pipelines/matrix/src/matrix/cli_commands/submit.py
@@ -48,8 +48,9 @@ def cli():
 @click.option("--dry-run", "-d", is_flag=True, default=False, help="Does everything except submit the workflow")
 @click.option("--from-nodes", type=str, default="", help="Specify nodes to run from", callback=split_string)
 @click.option("--is-test", is_flag=True, default=False, help="Submit to test folder")
+@click.option("--headless", is_flag=True, default=False, help="Disable prompts for confirmation")
 # fmt: on
-def submit(username: str, namespace: str, run_name: str, release_version: str, pipeline: str, quiet: bool, dry_run: bool, from_nodes: List[str], is_test: bool):
+def submit(username: str, namespace: str, run_name: str, release_version: str, pipeline: str, quiet: bool, dry_run: bool, from_nodes: List[str], is_test: bool, headless:bool):
     """Submit the end-to-end workflow. """
     if not quiet:
         log.setLevel(logging.DEBUG)
@@ -63,7 +64,7 @@ def submit(username: str, namespace: str, run_name: str, release_version: str, p
     if pipeline in ["fabricator", "test"]:
         raise ValueError("Submitting test pipeline to Argo will result in overwriting source data")
     
-    if from_nodes:
+    if not headless and from_nodes:
         if not click.confirm("Using 'from-nodes' is highly experimental and may break due to MLFlow issues with tracking the right run. Are you sure you want to continue?", default=False):
             raise click.Abort()
 
@@ -75,7 +76,7 @@ def submit(username: str, namespace: str, run_name: str, release_version: str, p
     pipeline_obj.name = pipeline
 
 
-    summarize_submission(run_name, namespace, pipeline, is_test, release_version)
+    summarize_submission(run_name, namespace, pipeline, is_test, release_version, headless)
     _submit(
         username=username,
         namespace=namespace,
@@ -85,6 +86,7 @@ def submit(username: str, namespace: str, run_name: str, release_version: str, p
         verbose=not quiet,
         dry_run=dry_run,
         template_directory=ARGO_TEMPLATES_DIR_PATH,
+        allow_interactions=not headless,
         is_test=is_test,
     )
 
@@ -166,7 +168,7 @@ def _submit(
         sys.exit(1)
 
 
-def summarize_submission(run_name: str, namespace: str, pipeline: str, is_test: bool, release_version: str):
+def summarize_submission(run_name: str, namespace: str, pipeline: str, is_test: bool, release_version: str, headless: bool):
     console.print(Panel.fit(
         f"[bold green]About to submit workflow:[/bold green]\n"
         f"Run Name: {run_name}\n"
@@ -180,8 +182,9 @@ def summarize_submission(run_name: str, namespace: str, pipeline: str, is_test: 
                   "If you need to make changes, please make this part of the next release.\n"
                   "Experiments (modelling pipeline) are nested under the release and can be overwritten.\n\n")
 
-    if not click.confirm("Are you sure you want to submit the workflow?", default=False):
-        raise click.Abort()
+    if not headless:
+        if not click.confirm("Are you sure you want to submit the workflow?", default=False):
+            raise click.Abort()
         
 
 def run_subprocess(


### PR DESCRIPTION
# Description of the changes <!-- required! -->

To enable `kedro submit ` run in GitHub Actions workflows for automating weekly and monthly release bump, I need to disable prompts for confirmation, otherwise it throws `Aborted` and exits, see [here](https://github.com/everycure-org/matrix/actions/runs/12430280146/job/34705418926)
I added `headless` flag to `submit` cli which disables human interactions.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensure the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] made corresponding changes to the documentation
- [ ] added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people


<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
