### PR TITLE
Have the triggered GitHub Action for creating new releases branch off from the commit on which the release workflow was actually triggered. 

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -53,8 +53,10 @@ jobs:
           git tag --annotate --message '' -- "${{env.release}}" "${{env.gitref}}"
 
       - name: Branch off
-        # To comply with the protected-branch policy
-        run: git switch -c release/${{env.release}}
+        # To comply with the protected-branch policy, we checkout a different
+        # branch, but from the commit that created the release.
+        # It should have been pushed, otherwise this errors out.
+        run: git switch -C release/${{env.release}} "${{env.gitref}}"
 
       - name: Setup Matrix CLI
         working-directory: apps/matrix-cli


### PR DESCRIPTION
With the change to the release process whereby we now need to branch off main, possibly creating a few more commits and then pushing those, we need to checkout that branch too, and reset it to the point where the release was triggered.

## Fixes / Resolves the following issues:

- GitHub Actions complained that it could fast-forward, whereas our assumption was that we were already on the tip of the branch.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensure the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] made corresponding changes to the documentation
- [ ] added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people


<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
