### PR TITLE
Use the correct Jinja template placeholders in the call to `render`.

### DIFF
--- a/apps/matrix-cli/src/matrix_cli/commands/releases.py
+++ b/apps/matrix-cli/src/matrix_cli/commands/releases.py
@@ -142,9 +142,7 @@ def get_release_notes(since: str, model: str) -> str:
     response = invoke_model(prompt, model)
 
     authors = pr_details_df["author"].unique()
-    return get_template("release_notes.tmpl").render(
-        current_date=date.today().isoformat(), authors=authors, notes=response
-    )
+    return get_template("release_notes.tmpl").render(date=date.today().isoformat(), authors=authors, notes=response)
 
 
 def get_release_template() -> str:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

This is a hotfix for a Jinja `template.render` call that is used to create the release notes, which is currently blocking the docs from being built.

## Fixes / Resolves the following issues:

- Cannot merge data release PRs

