### PR TITLE
Have the regular release action push its new branch, so there is an '@{upstream}' reference.

### DIFF
--- a/.github/workflows/submit-kedro-pipeline.yml
+++ b/.github/workflows/submit-kedro-pipeline.yml
@@ -1,8 +1,8 @@
-name: Automate kedro submit release run periodically
+name: Periodically run kedro kg-release
 
 on:
   schedule:
-    - cron: '0 12 1 * 2' # At 10:25 CET on the 1st day of the month and on Tuesday.
+    - cron: '10 13 1 * 2' # At 14:10 CET on the 1st day of the month and on Tuesday.
 
 env:
   project_id: 'mtrx-hub-dev-3of'
@@ -102,10 +102,8 @@ jobs:
       - name: Branch off
         run: |
           git switch -C release/${{env.release_version}} "${{github.ref_name}}"
-          git add gha-kubeconfig* 
-          git commit -m "add kubeconfig file generated while authentication"
-          git status
-
+          git push
+          
       - name: Submit the kedro pipeline
         working-directory: pipelines/matrix
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ infra/**/Chart.lock
 gha-creds-*.json
 
 pipelines/matrix/src/matrix/pipelines/matrix_generation/matrix.code-workspace
+
+# Artifact from the google-github-actions/get-gke-credentials@v1
+# Having it would not allow us to trigger a release from GH Actions,
+# since the repo would be in a dirty state.
+gha-kubeconfig*


### PR DESCRIPTION
# Description of the changes <!-- required! -->

This PR forces the GitHub Actions to link its local release/xyz branch to an upstream (which is on GitHub), therefor allowing the use of the `@{upstream}` reference, that is used to check whether the local state is in sync with the remote (no uncommitted changes), which in turn is needed to ensure we can check out the exact commit that triggered the release.
