### PR TITLE
Fix the label selector in the workflow-controller Service.

### DIFF
--- a/infra/argo/applications/workflows/templates/metrics.yaml
+++ b/infra/argo/applications/workflows/templates/metrics.yaml
@@ -13,7 +13,7 @@ spec:
     protocol: TCP
     targetPort: 9090
   selector:
-      app: argo-workflows-workflow-controller
+      app.kubernetes.io/name: argo-workflows-workflow-controller
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

Currently, the `workflow-controller-metrics` Service does not map to any pods. It is supposed to map to the pods belonging to the `argo-workflows-workflow-controller` service. These pods have the following label:
`app.kubernetes.io/name=argo-workflows-workflow-controller`. This PR corrects the selector on the `workflow-controller-metrics` Service to match that label. Expecting that the `workflow-controller-metrics` will start having pods once applied.


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
