### PR TITLE
Change the selector on the ServiceMonitor to match the one from the Service it targets.

### DIFF
--- a/infra/argo/applications/workflows/templates/metrics.yaml
+++ b/infra/argo/applications/workflows/templates/metrics.yaml
@@ -25,4 +25,4 @@ spec:
   - port: metrics
   selector:
     matchLabels:
-      app: argo-workflows-workflow-controller
+      app: workflow-controller


### PR DESCRIPTION
….

# Description of the changes <!-- required! -->

Prometheus is not scraping the argo-workflow metrics. Possible cause is the wrong selector on the ServiceMonitor object.
This PR fixes that. If it is indeed the fix, we should start noticing the service `workflow-controller-metrics` in prometheus ui:

`kubectl port-forward svc/kube-prometheus-stack-prometheus -n observability 9090:9090`
<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
