### PR TITLE
hotfix: add missing Makefile target

### DIFF
--- a/pipelines/matrix/Makefile
+++ b/pipelines/matrix/Makefile
@@ -120,6 +120,9 @@ licenses_container: docker_build
 		-v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy  \
 		image --scanners license --severity UNKNOWN,CRITICAL $(dev_docker_image)
 
+clean_sa_key:
+	rm -f $(SA_KEY_PATH)
+
 clean: clean_sa_key
 	@echo "cleaning various cache locations to ensure clean installation is possible"
 	@echo "this may be necessary e.g. when updating one of our local packages"


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Introduces a missing target that was a prerequisite of another, commonly used one.

## Fixes / Resolves the following issues:

As reported by users, `make clean` references a non-existing make target, which would make `make` stop early.

