### PR TITLE
hotfix: catalog references aren't parameters

### DIFF
--- a/pipelines/matrix/conf/cloud/integration/catalog.yml
+++ b/pipelines/matrix/conf/cloud/integration/catalog.yml
@@ -15,26 +15,48 @@ _bigquery_ds: &_bigquery_ds
 # Overwriting the base catalog to use the bigquery datasets
 
 # Transformed nodes/edges
-integration.int.{source}.nodes:
+integration.int.rtx_kg2.nodes:
   <<: *_bigquery_ds
-  filepath: ${globals:paths.integration}/int/{source}/nodes
+  filepath: ${globals:paths.integration}/int/${source}/nodes
   table: ${source}_nodes_transformed
 
-integration.int.{source}.edges:
+integration.int.rtx_kg2.edges:
   <<: *_bigquery_ds
-  filepath: ${globals:paths.integration}/int/{source}/edges
+  filepath: ${globals:paths.integration}/int/${source}/edges
   table: ${source}_edges_transformed
 
 # Normalised nodes/edges
-integration.int.{source}.nodes.norm@spark:
+integration.int.rtx_kg2.nodes.norm@spark:
   <<: *_bigquery_ds
-  filepath: ${globals:paths.integration}/int/{source}/nodes.norm
+  filepath: ${globals:paths.integration}/int/${source}/nodes.norm
   table: ${source}_nodes_normalized
 
-integration.int.{source}.edges.norm@spark:
+integration.int.rtx_kg2.edges.norm@spark:
   <<: *_bigquery_ds
-  filepath: ${globals:paths.integration}/int/{source}/edges.norm
+  filepath: ${globals:paths.integration}/int/${source}/edges.norm
   table: ${source}_edges_normalized
+
+integration.int.ec_medical_team.nodes:
+  <<: *_bigquery_ds
+  filepath: ${globals:paths.integration}/int/${source}/nodes
+  table: ${source}_nodes_transformed
+
+integration.int.ec_medical_team.edges:
+  <<: *_bigquery_ds
+  filepath: ${globals:paths.integration}/int/${source}/edges
+  table: ${source}_edges_transformed
+
+# Normalised nodes/edges
+integration.int.ec_medical_team.nodes.norm@spark:
+  <<: *_bigquery_ds
+  filepath: ${globals:paths.integration}/int/${source}/nodes.norm
+  table: ${source}_nodes_normalized
+
+integration.int.ec_medical_team.edges.norm@spark:
+  <<: *_bigquery_ds
+  filepath: ${globals:paths.integration}/int/${source}/edges.norm
+  table: ${source}_edges_normalized
+
 
 # Unified nodes/edges
 integration.prm.unified_nodes:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

`kedro submit --username foo --run-name bar --release-version v0.2.5 -p embeddings --is-test` is failing because the `{source}` literal used in the catalog are picked up as such, as literals. They are not interpolated.

The easy way forward is to simply duplicate the references for each source currently in the knowledge graph.

## Fixes / Resolves the following issues:

- main broken.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
