### PR TITLE
Comment out ingest_nodes_with_embeddings

### DIFF
--- a/pipelines/matrix/src/matrix/pipelines/data_release/pipeline.py
+++ b/pipelines/matrix/src/matrix/pipelines/data_release/pipeline.py
@@ -36,13 +36,6 @@ def create_pipeline(**kwargs) -> Pipeline:
                 outputs="data_release.prm.bigquery_nodes",
                 name="release_nodes_to_bigquery",
             ),
-            # release to neo4j
-            ArgoNode(
-                func=lambda x: x,
-                inputs=["embeddings.feat.nodes"],
-                outputs="data_release.feat.nodes_with_embeddings",
-                name="ingest_nodes_with_embeddings",
-            ),
             ArgoNode(
                 func=ingest_nodes,
                 inputs=["integration.prm.filtered_nodes"],
@@ -72,6 +65,14 @@ def create_pipeline(**kwargs) -> Pipeline:
                 tags=["kgx"],
             ),
             last_node,
+            # NOTE: Enable when the embeddings pipeline worked piror to this pipeline
+            # # release to neo4j
+            # ArgoNode(
+            #     func=lambda x: x,
+            #     inputs=["embeddings.feat.nodes"],
+            #     outputs="data_release.feat.nodes_with_embeddings",
+            #     name="ingest_nodes_with_embeddings",
+            # ),
             # NOTE: Enable if you want embeddings
             # ArgoNode(
             #     func=lambda _, x: x,


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Since the `embeddings` pipeline is not stable now, we removed it from `kg_release` pipeline. However, the node `ingest_nodes_with_embeddings` in `data_release` pipeline takes the output of embeddings and releases it to neo4j.
To ensure a successful weekly e2e `kg_release` run (`data_enginneering`+`data_release`), we commented out the node.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
