### PR TITLE
Revert window size to 10 for Node2Vec Embeddings

### DIFF
--- a/pipelines/matrix/conf/base/embeddings/parameters.yml
+++ b/pipelines/matrix/conf/base/embeddings/parameters.yml
@@ -81,7 +81,7 @@ embeddings.topological_estimator:
   negative_sampling_rate: 5
   walk_length: 30
   walks_per_node: 10
-  window_size: 100
+  window_size: 10
 
 # embeddings.topological_estimator:
 #   _object: matrix.pipelines.embeddings.graph_algorithms.GDSGraphSage


### PR DESCRIPTION
Our best performing model (https://mlflow.platform.dev.everycure.org/#/experiments/115/runs/f50acfac0b1e4a76964610910dab5bc0) was achieved using window_size=10 as a parameter for topological embeddings. Somehow the pipeline is now using window_size=100. Let's revert it back to baseline

# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
