### PR TITLE
[AIP-169]: deleting workflows and templates older than 30d 

### DIFF
--- a/infra/argo/applications/workflows/templates/cronjob.yml
+++ b/infra/argo/applications/workflows/templates/cronjob.yml
@@ -18,18 +18,20 @@ spec:
           containers:
           - name: argo-cli
             image: argoproj/argocli:latest
-            command:
-            - /bin/sh
-            - -c
-            - |
-              argo delete --older 30d --completed --all-namespaces
+            args:
+            - delete
+            - --older
+            - 30d
+            - --completed
+            - --namespace
+            - argo-workflows
             resources:
               requests:
                 cpu: 100m
                 memory: 128Mi
               limits:
                 cpu: 200m
-                memory: 256Mi
+                memory: 1Gi
           restartPolicy: OnFailure
           serviceAccountName: argo-workflow-cleanup
 ---
@@ -51,20 +53,20 @@ spec:
           containers:
           - name: argo-cli
             image: argoproj/argocli:latest
-            command:
-            - /bin/sh
-            - -c
-            - |
-              # Simply delete all workflow templates
-              echo "Deleting all workflow templates"
-              argo template delete --all --all-namespaces
+            args:
+            - template
+            - delete
+            - --all
+            - --namespace
+            - argo-workflows
+
             resources:
               requests:
                 cpu: 100m
                 memory: 128Mi
               limits:
                 cpu: 200m
-                memory: 256Mi
+                memory: 1Gi
           restartPolicy: OnFailure
           serviceAccountName: argo-workflow-cleanup
 ---
@@ -73,6 +75,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-workflow-cleanup
+  namespace: argo-workflows
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -97,4 +100,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo-workflow-cleanup
-  namespace: default
+  namespace: argo-workflows


### PR DESCRIPTION
CRON job to clean up argo resources as the system otherwise becomes slow and unstable.


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- buggy argo workflows UI, at leaset partially


# Checklist:

- tested this by triggering the cronjob manually
![Screenshot 2025-03-11 at 17 03 19](https://github.com/user-attachments/assets/168eca6a-fd99-4f34-a95b-9478e5b95471)


<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
