### PR TITLE
Adding DM folks to specific pieces

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,8 +3,8 @@
 # -------------------------------------------------------------------------------------------------
 
 * @lvijnck @pascalwhoop @piotrkan @JacquesVergine @oliverw1
-docs/ @alexeistepa @leelancashire
-pipelines/matrix/** @alexeistepa @leelancashire 
-infra/ @emil-k
+docs/ @alexeistepa @leelancashire @oliverw1
+pipelines/matrix/** @alexeistepa @leelancashire @oliverw1 @Siyan-Luo @emil-k
+infra/ @emil-k @oliverw1
 
 


### PR DESCRIPTION
Codeowners syntax means more specific pieces override the asterisk, see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
