### PR TITLE
Fix bug where MLFLOW_RUN_ID=None

### DIFF
--- a/pipelines/matrix/src/matrix/hooks.py
+++ b/pipelines/matrix/src/matrix/hooks.py
@@ -148,9 +148,9 @@ class MLFlowHooks:
 
         if not runs:
             logger.info("creating run")
-            # Now that we optionally pass in a run_id from kedro experiment, it will be set to None in this case
-            # MLFlow tries to use the MLFLOW_RUN_ID=None, which we need to explicitly unset
-            del os.environ["MLFLOW_RUN_ID"]
+            # For some reason MLFLOW_RUN_ID is set to "None" rather than None, so it tries to find this run id
+            if os.environ.get("MLFLOW_RUN_ID") == "None":
+                del os.environ["MLFLOW_RUN_ID"]
             run = mlflow.start_run(run_name=run_name, experiment_id=experiment_id)
             mlflow.set_tag("created_by", "kedro")
             return run.info.run_id


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

Error was raised in the sampling pipeline: https://every-cure.slack.com/archives/C07NAAVLM43/p1741772428848799?thread_ts=1741355147.453709&cid=C07NAAVLM43

`RESOURCE_DOES_NOT_EXIST: Run with id=None not found`

Since making this change: https://github.com/everycure-org/matrix/pull/1222, we introduce an optional `MLFLOW_RUN_ID` environment variable. It is only set when using `kedro experiment run` to ensure that all nodes from the run log to the same MLFLow ID.

https://github.com/everycure-org/matrix/pull/1222/files#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R129

In `kedro submit`, the run configuration is managed in the hooks. The change meant that now when we trigger `kedro submit`, ~there is an env var `MLFLOW_RUN_ID=None`~

UPDATED: The problem was actually that the env var was coming through as a string `MLFLOW_RUN_ID="None"`. So MLFlow takes this string as the literal run id! I"m not sure why it is being set as a string, and that would be worth looking at too. But the fix still works for now to unset this incorrect variable

In the hook, if the run id is not already set (true for `kedro submit`, not for `kedro experiment create`), we create and start the run https://github.com/everycure-org/matrix/blob/main/pipelines/matrix/src/matrix/hooks.py#L151

From MLFlow `start_run`: https://github.com/mlflow/mlflow/blob/master/mlflow/tracking/fluent.py#L234
> If you pass a ``run_id`` or the ``MLFLOW_RUN_ID`` environment variable is set,
    ``start_run`` attempts to resume a run with the specified run ID and
    other parameters are ignored.

---

We have historically passed MLFlow an `experiment_id` and `run_name`
```run = mlflow.start_run(run_name=run_name, experiment_id=experiment_id)```

But, since the change last week, we now also have an env var ~`MLFLOW_RUN_ID=None`~ `MLFLOW_RUN_ID="None"`. Annoyingly, MLFlow does not ignore the null value and continue with the provided params, but continues to attempt to start the run None.

----

The long term fix is to completely [deprecate](https://linear.app/everycure/issue/MATRIX-557/deprecate-kedro-submit) `kedro submit`. But that requires some more work to deal with the I[AP browser auth flow](https://linear.app/everycure/issue/EC-167/skip-browser-login-for-iap-token-in-github-actions) when running in the cloud. 

So the short term fix for today is to _unset_ the `MLFLOW_RUN_ID` (`None`) env var, and then let MLFlow proceed with creating and starting the run as it did previously.

Here is a passing sample run with the changes : https://github.com/everycure-org/matrix/actions/runs/13832573842/job/38700414607

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
