### PR TITLE
WIP: Create release for RTX 2.10.0 with ground truth 2.7.3

### DIFF
--- a/pipelines/matrix/compose/docker-compose.yml
+++ b/pipelines/matrix/compose/docker-compose.yml
@@ -42,6 +42,7 @@ services:
   node-synonymizer:
     build: "../../../services/synonymizer"
     environment:
+      # Node synonymizer OK on old version?
       DB_CONNECTION_STR: /usr/src/app/assets/node_synonymizer_v1.0_KG2.7.3.sqlite
     volumes:
       # NOTE: Asset files are really big, so mounting them in

--- a/pipelines/matrix/conf/base/fabricator/parameters.yml
+++ b/pipelines/matrix/conf/base/fabricator/parameters.yml
@@ -94,9 +94,9 @@ fabricator.rtx_kg2:
           - infores:ubergraph
           - infores:snpeff
       # For version 2.10
-      # primary_knowledge_source:
-      #   type: faker
-      #   provider: name
+      primary_knowledge_source:
+        type: faker
+        provider: name
       publications:string[]:
         type: generate_random_arrays
         delimiter: "\u01c2"

--- a/pipelines/matrix/conf/base/globals.yml
+++ b/pipelines/matrix/conf/base/globals.yml
@@ -20,7 +20,7 @@ versions:
 
 data_sources:
   rtx_kg2:
-    version: &_rtx_kg_version v2.7.3 #when bumping to 2.10, we should stop to limit PMID for the semmed filtering
+    version: &_rtx_kg_version v2.10.0 #when bumping to 2.10, we should stop to limit PMID for the semmed filtering
   robokop:
     version: c5ec1f282158182f
   spoke:
@@ -40,7 +40,8 @@ data_sources:
     # check releases here: https://github.com/everycure-org/matrix-disease-list/releases
     version: "February 2025 release 5"
   gt:
-    version: *_rtx_kg_version # NOTE: This is the version of the GT dataset which was developed for rtx-kg2 as a part of KGML-xDTD pipeline
+    # This release is RTX v2.10.0 with GT 2.7.3
+    version: v2.7.3 # NOTE: This is the version of the GT dataset which was developed for rtx-kg2 as a part of KGML-xDTD pipeline
   drugmech:
     # check releases here: https://github.com/SuLab/DrugMechDB/releases/ 
     version: 2.0.1

--- a/pipelines/matrix/src/matrix/pipelines/integration/transformers/rtxkg2.py
+++ b/pipelines/matrix/src/matrix/pipelines/integration/transformers/rtxkg2.py
@@ -55,7 +55,7 @@ class RTXTransformer(GraphTransformer):
         # fmt: off
         return (
             edges_df
-            .withColumn("aggregator_knowledge_source",   f.split(f.col("knowledge_source:string[]"), RTX_SEPARATOR)) # RTX KG2 2.10 does not exist
+            .withColumn("aggregator_knowledge_source",   f.split(f.col("primary_knowledge_source"), RTX_SEPARATOR))
             .withColumn("publications",                  f.split(f.col("publications:string[]"), RTX_SEPARATOR))
             .withColumn("upstream_data_source",          f.array(f.lit("rtxkg2")))
             .withColumn("knowledge_level",               f.lit(None).cast(T.StringType()))

--- a/pipelines/matrix/src/matrix/settings.py
+++ b/pipelines/matrix/src/matrix/settings.py
@@ -48,7 +48,7 @@ DYNAMIC_PIPELINES_MAPPING = generate_dynamic_pipeline_mapping(
         "integration": [
             {"name": "rtx_kg2", "integrate_in_kg": True},
             # {"name": "spoke", "integrate_in_kg": True},
-            {"name": "robokop", "integrate_in_kg": True},
+            # {"name": "robokop", "integrate_in_kg": False},
             {"name": "ec_medical_team", "integrate_in_kg": True},
             {"name": "drug_list", "integrate_in_kg": False, "has_edges": False},
             {"name": "disease_list", "integrate_in_kg": False, "has_edges": False},


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

- Some drugs in the drugs list were not found in RTX 2.7.3
- From manual investigation, they were identified in RTX 2.10.0
- This PR creates a release for RTX 2.10.0 as `v0.4.3` 

Preliminary findings ~300 additional drugs from drugs list will be able to generate scores [more analysis to come, just want to get the ball rolling here]




## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- https://linear.app/everycure/issue/DATA-279/test-release-of-rtx-210-with-ground-truth-273


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
