### PR TITLE
Fix test sample pipeline by adding filtering step

### DIFF
--- a/pipelines/matrix/src/matrix/pipeline_registry.py
+++ b/pipelines/matrix/src/matrix/pipeline_registry.py
@@ -78,7 +78,7 @@ def register_pipelines() -> Dict[str, Pipeline]:
         + pipelines["ingest_to_N4J"]
     )
     pipelines["test_sample"] = (
-        + pipelines["filtering"]
+        pipelines["filtering"]
         + pipelines["embeddings"]
         + pipelines["modelling_run"]
     )


### PR DESCRIPTION
The test_sample pipeline is [currently failing](https://argo.platform.dev.everycure.org/workflows/argo-workflows/scheduled-sampled-test-749dfa91?tab=workflow&nodeId=scheduled-sampled-test-749dfa91-1123423183&sidePanel=logs:scheduled-sampled-test-749dfa91-1123423183:main&uid=76ad7340-e33f-432c-9ec1-1add5452cdd5).

It runs just after the integration pipeline, so it should include the filtering pipeline. Right now it doesn't, and only covers embedding and modelling.