### PR TITLE
auto-encrypt credential files that might be dropped by mistake in parent folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 infra/secrets/common/** filter=git-crypt diff=git-crypt
-infra/secrets/common/** filter=git-crypt diff=git-crypt
+infra/secrets/* filter=git-crypt diff=git-crypt
 # the 'default' key is the one used for the dev environment (historically like this)
 infra/secrets/dev/** filter=git-crypt diff=git-crypt
 infra/secrets/prod/** filter=git-crypt-prod diff=git-crypt-prod


### PR DESCRIPTION
Secret files should be placed inside of `/infra/secrets/<env_name>`.
If someone, however, commits and pushes a sensitive file directly into `/infra/secrets/`, it won't be encrypted and the secret will have to be rotated. This PR prevents this.

# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
