### PR TITLE
neo4j wrong config map for advertised URL

### DIFF
--- a/infra/argo/app-of-apps/templates/neo4j.yaml
+++ b/infra/argo/app-of-apps/templates/neo4j.yaml
@@ -24,7 +24,7 @@ spec:
         neo4j:
           config:
             server.default_advertised_address: "neo4j.{{ .Values.spec.source.environment }}.everycure.org"
-            bolt.advertised_address: "neo4j.{{ .Values.spec.source.environment }}.everycure.org:7687"
+            server.bolt.advertised_address: "neo4j.{{ .Values.spec.source.environment }}.everycure.org:7687"
           services:
             neo4j:
               annotations:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

```
    # server.directories.import: /var/lib/neo4j/import
    server.default_advertised_address: dummy-replaced-by-helm-override-from-app-of-apps
    server.bolt.advertised_address: dummy-replaced-by-helm-override-from-app-of-apps

```

needs replacing but the app-of-apps file was missing the `server.` at the beginning

## Fixes / Resolves the following issues:

lack of access to neo4j from UI unless one replaces string

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
