### PR TITLE
keep argo templates for 30 days instead of daily delete

### DIFF
--- a/infra/argo/applications/workflows/templates/cronjob.yml
+++ b/infra/argo/applications/workflows/templates/cronjob.yml
@@ -56,10 +56,10 @@ spec:
             args:
             - template
             - delete
-            - --all
+            - --older
+            - 30d
             - --namespace
             - argo-workflows
-
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Currently argo templates are deleted daily. This makes it impossible to inspect the workflow template and see the exact command that was run, flags set, arguments, etc.

This PR changes the workflow template TTL to 30 days.

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
