### PR TITLE
mini improvement in run names

### DIFF
--- a/.github/workflows/submit-kedro-pipeline.yml
+++ b/.github/workflows/submit-kedro-pipeline.yml
@@ -134,7 +134,7 @@ jobs:
             --username GH-Actions-bot \
             --namespace argo-workflows \
             --experiment-name scheduled-kg-release \
-            --run-name auto-kg-release \
+            --run-name auto-kg-release-${{ env.release_version }} \
             --release-version "${{ env.release_version }}" \
             --pipeline ${RELEASE_PIPELINE} \
             --headless


### PR DESCRIPTION
![CleanShot 2025-04-16 at 13 54 51@2x](https://github.com/user-attachments/assets/dc7afde1-48fe-4b89-bc12-3f29b814d1cc)
not really nice to see what run created what release