### PR TITLE
Nelson/data 476 fix ci failure in automated sampling pipeline for cloning

### DIFF
--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -89,10 +89,9 @@ jobs:
         with: 
           sparse-checkout: |
             pipelines/matrix/
+          token: ${{ secrets.PAT }}
+          submodules: recursive
           persist-credentials: true
-      - name: checkout submodule
-        run: |
-          git submodule update --init --recursive
       - uses: 'google-github-actions/auth@v2'
         with:
           project_id: ${{vars.project_id}}


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Used `github checkout@v4` to recursively update our submodules. see ticket: https://linear.app/everycure/issue/DATA-476/fix-ci-failure-in-automated-sampling-pipeline-for-cloning-packages

Documentation I read is here: https://github.com/actions/checkout

## Fixes / Resolves the following issues:
Unable to `git submodule --init --recursive` due to permission issue.
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [] Made corresponding changes to the documentation
- [] Added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
