### PR TITLE
Fix headless flag removing manual release prompt

### DIFF
--- a/pipelines/matrix/src/matrix/cli_commands/experiment.py
+++ b/pipelines/matrix/src/matrix/cli_commands/experiment.py
@@ -188,7 +188,7 @@ def run(
         log.setLevel(logging.DEBUG)
 
     if pipeline in ("data_release", "kg_release"):
-        if not headless or not confirm_release:
+        if not headless and not confirm_release:
             if not click.confirm(
                 "Manual release submission detected, releases must be submitted via the release pipeline. Are you sure you want to create a manual release?",
                 default=False,


### PR DESCRIPTION
When submitting a release pipeline the `headless` flag should remove all manual user prompts, but one was added in [this PR](https://github.com/everycure-org/matrix/pull/1489). With this user prompt, the github actions will fail.

We are here correcting it so that headless removes the user prompt.