### PR TITLE
bugfix - make sentinel data release the last node.

### DIFF
--- a/pipelines/matrix/src/matrix/pipelines/data_release/pipeline.py
+++ b/pipelines/matrix/src/matrix/pipelines/data_release/pipeline.py
@@ -6,7 +6,6 @@ from matrix.pipelines.data_release.nodes import unified_edges_to_kgx, unified_no
 
 # Last node is made explicit because there's a kedro hook after_node_run
 # being triggered after the completion of the last node of this pipeline.
-
 # This node is monitored by the data release workflow for successful completion.
 # It's a sentinel indicating all data-delivering nodes are really done executing.
 # It _must_ be the very last node in this pipeline.


### PR DESCRIPTION
# Description of the changes <!-- required! -->

The data release node was triggered prematurely, while one of the nodes that was ingesting edges to neo4j was still running. It turned out it was missing one dependency which was added in the line above. Verified running kedro viz that with this addition the data release was indeed the very last node.

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
