### PR TITLE
add unit tests whether the sentinel data release node runs last

### DIFF
--- a/pipelines/matrix/tests/pipelines/test_data_release.py
+++ b/pipelines/matrix/tests/pipelines/test_data_release.py
@@ -46,29 +46,3 @@ class TestDataReleasePipeline:
         assert (
             upstream_nodes == other_nodes
         ), f"Last node should depend on all other nodes. Missing dependencies: {other_nodes - upstream_nodes}"
-
-    def test_last_node_inputs_include_all_critical_outputs(self):
-        """
-        Given a data release pipeline
-        When examining dataset flows
-        Then the last_node inputs should encompass all critical outputs from data-producing nodes
-        """
-        # GIVEN
-        pipeline = create_pipeline()
-
-        # WHEN
-        # Find the last_node and its inputs
-        last_node = next(node for node in pipeline.nodes if node.name == last_node_name)
-        last_node_inputs = set(last_node.inputs)
-
-        # Collect all datasets that are outputs of data-producing nodes
-        # Focus on KGX datasets which are the critical outputs
-        kgx_outputs = set()
-        for node in pipeline.nodes:
-            if node.name != last_node_name and node.tags and "kgx" in node.tags:
-                kgx_outputs.update(node.outputs)
-
-        # THEN
-        # Check if all critical KGX outputs are inputs to the last_node
-        missing_inputs = [output for output in kgx_outputs if output not in last_node_inputs]
-        assert not missing_inputs, f"Last node should consume all critical KGX outputs, but missing: {missing_inputs}"


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Ensures the last node of the data release pipeline, the sentinel node that triggers the data release actions, is truly the last node, and starts running only once all other nodes finish. 
<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
