### PR TITLE
Update core entities' version to v0.1.1

### DIFF
--- a/pipelines/matrix/conf/base/globals.yml
+++ b/pipelines/matrix/conf/base/globals.yml
@@ -43,10 +43,10 @@ data_sources:
     version: 20230309 # NOTE: Here 0309 is a period of time (here Mar to Sep 2023)
   drug_list:
     # check releases here: https://github.com/everycure-org/core-entities/releases
-    version: v0.1.0
+    version: v0.1.1
   disease_list:
     # check releases here: https://github.com/everycure-org/core-entities/releases
-    version: v0.1.0
+    version: v0.1.1
   gt:
     version: *_rtx_kg_version # NOTE: This is the version of the GT dataset which was developed for rtx-kg2 as a part of KGML-xDTD pipeline
   drugmech:


### PR DESCRIPTION
The previous core entities version (v0.1.0) was missing columns for disease specific experiments. Updated version (v0.1.1) has them