### PR TITLE
Harden GitHub actions against potential attackers by Adding Approval step to production in Google CloudBuild

### DIFF
--- a/infra/modules/components/cloudbuild/trigger.tf
+++ b/infra/modules/components/cloudbuild/trigger.tf
@@ -4,6 +4,10 @@ resource "google_cloudbuild_trigger" "terrgrunt_trigger" {
   location    = var.location
   description = "Trigger for terragrunt apply on push to ${var.github_repo_deploy_branch} branch"
 
+  approval_config {
+    approval_required = true
+  }
+
   repository_event_config {
     repository = google_cloudbuildv2_repository.matrix_repo.id
     push {


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

As we are open-sourcing, we would like to harden our production env to have a approval process in place in production. Once code is merged to main, `terraform apply` for production will not happen unless approved.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- Risk of accidental deployment to production after merging code into main


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
