### PR TITLE
Do not refresh Credentials for GCP SA if it is a Github Action

### DIFF
--- a/pipelines/matrix/src/matrix/utils/kubernetes.py
+++ b/pipelines/matrix/src/matrix/utils/kubernetes.py
@@ -49,8 +49,10 @@ def can_talk_to_kubernetes(
                 pretty_report_on_error(e)
 
     def refresh_kube_credentials() -> None:
+        """Refresh kubectl credentials for the specified GKE cluster."""
+        # We do not want to refresh credentials if running in GitHub Actions, as it is not needed there.
+        # In GitHub Actions, the credentials are already set up by the action.
         if not environ.get("GITHUB_ACTIONS"):
-            # In GitHub Actions, we use the GCP_TOKEN environment variable to authenticate.
             logger.debug("Refreshing kubectl credentials…")
             refresh_command = (
                 f"gcloud container clusters get-credentials {cluster_name} --project {project} --region {region}"


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->
This PR disables refreshing credentials when running in GitHub action. We do not want to refresh credentials as it is already provided by the action.

Working sampling run: https://github.com/everycure-org/matrix/actions/runs/15679153314/job/44166438507

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- Error during submission: Calling 'kubectl get nodes' failed, with stderr:


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [X] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
