### PR TITLE
Allow sampling pipeline release_version parameter to be null

### DIFF
--- a/.github/workflows/scheduled-sampling-pipeline.yml
+++ b/.github/workflows/scheduled-sampling-pipeline.yml
@@ -2,12 +2,12 @@ name: Scheduled Sampling Pipeline
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # daily at 5am GMT
+    - cron: '0 0 * * *'  # every day at midnight GMT
   workflow_dispatch: 
     inputs:
       release_version:
-        description: 'Version to deploy in format vX.Y.Z'
-        required: true
+        description: 'Version to deploy in format vX.Y.Z. If not provided, the latest tag will be used.'
+        required: false
         type: string
 env:
   project_id: 'mtrx-hub-dev-3of'


### PR DESCRIPTION
# Description of the changes <!-- required! -->

A release version had to be manually typed to run the sampling pipeline, while this is a useful feature to test on previous releases, it was causing problems when a release was mistyped. 

The new default behaviour is to use the latest tag if no version is provided.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
