### PR TITLE
Added atomic and timeout to Helm release configuration in Terraform for stability

### DIFF
--- a/infra/modules/stacks/compute_cluster/argo/argo.tf
+++ b/infra/modules/stacks/compute_cluster/argo/argo.tf
@@ -35,11 +35,14 @@ resource "kubernetes_secret" "argo_secret" {
 }
 
 resource "helm_release" "argo" {
-  depends_on = [kubernetes_namespace.argo_ns, kubernetes_secret.argo_secret]
-  name       = "argo"
-  repository = "https://argoproj.github.io/argo-helm"
-  chart      = "argo-cd"
-  namespace  = var.namespace
+  depends_on    = [kubernetes_namespace.argo_ns, kubernetes_secret.argo_secret]
+  name          = "argo"
+  repository    = "https://argoproj.github.io/argo-helm"
+  chart         = "argo-cd"
+  namespace     = var.namespace
+  timeout       = 600
+  atomic        = true
+  recreate_pods = true
 
   # pass through ssl to enable grpc/https for argocd CLI, see
   # https://argoproj.github.io/argo-cd/operator-manual/ingress/#kubernetesingress-nginx


### PR DESCRIPTION
# Description of the changes <!-- required! -->

We encountered a Helm deployment failure due to a stuck release state:

`Error: another operation (install/upgrade/rollback) is in progress`

This typically happens when a previous Helm operation (e.g., install, upgrade) fails or is interrupted, leaving the release in a pending state (PENDING-UPGRADE, PENDING-ROLLBACK, etc.). This blocks subsequent Terraform runs.

Proposed change:

Update the helm_release resource in Terraform to include the following options:

```hcl
atomic  = true
timeout = 600
```

atomic = true: Ensures the release is rolled back automatically if the upgrade fails, leaving no partial state.

timeout = 600: Extends the default timeout (300s) to give long-running operations more time to complete.

Benefits:

Prevents dangling release states that block future deploys.

Ensures failed upgrades are rolled back cleanly.

Reduces the need for manual intervention in CI/CD pipelines.

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- `Error: another operation (install/upgrade/rollback) is in progress`


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
