### PR TITLE
Update onboarding issue link in 'Getting Started'

### DIFF
--- a/docs/src/getting_started/index.md
+++ b/docs/src/getting_started/index.md
@@ -33,8 +33,6 @@ We envision there are three types of users and contributors who might be interes
 
 We welcome all contributors however this guide is primarily designed for pipeline and project contributors. If you are interested in the infrastructure side, we would recommend completing this guide but focusing mainly on the [infrastructure](../infrastructure/index.md) part of the documentation.
 
-As you onboard, we really recommend creating an [onboarding issue](https://github.com/everycure-org/matrix/issues/new?assignees=&labels=onboarding&projects=&template=onboarding.md&title=%3Cfirstname%3E+%3Clastname%3E) to help you navigate your progress. This way we can also support you in case of any bottlenecks or errors.
-    
 
 [Get Started with First Steps :material-arrow-right:](./first_steps/index.md){ .md-button .md-button--primary }
      


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->
We previously had an Onboarding GitHub issue with a checklist of setting up access to EC infrastructure. We have since restructured our documentation for Open Source contributors, so this checklist should only apply to EC employees or subcontractors but not open source contributors. We have already transferred the checklist to [Linear](https://linear.app/everycure/team/MATRIX/new?template=df9ac006-fb9f-44f9-a27f-42a1bd3a6aff) which internal/subcontractors will have access to, and removed the onboarding issue template from our GitHub. Now we need to remove the link to the GitHub checklist in our docs for this so that people are not confused by this broken link

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- AIP-392


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [x] Made corresponding changes to the documentation

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
