### PR TITLE
Update argo workflow to use `trimmed_kedro_nodes` in workflow template for labels

### DIFF
--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -350,7 +350,7 @@ spec:
           - name: kedro_nodes
             value: {{ task.nodes }}
           - name: trimmed_kedro_nodes
-            value: {{ task.nodes[:36].rstrip('_-.') }}
+            value: {{ task.nodes[:36].rstrip('_-.').replace(',', '-') }}
           - name: num_gpus
             value: {{ task.resources.num_gpus }}
           - name: memory_request


### PR DESCRIPTION

# Description of the changes <!-- required! -->

This pull request updates the `argo_wf_spec.tmpl` file to introduce a new parameter, `trimmed_kedro_nodes`, which is used in place of `kedro_nodes` in several parts of the workflow specification. This change ensures that node names are trimmed to a maximum length of 36 characters and any trailing underscores, dashes, or dots are removed so that the label limit of 36 characters is respected.

### Updates to workflow parameters:

* Replaced the `kedro_nodes` parameter with `trimmed_kedro_nodes` in multiple locations to ensure the use of trimmed node names. (`[[1]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61L88-R88)`, `[[2]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61L231-R232)`)

### Addition of new parameter:

* Added a new parameter, `trimmed_kedro_nodes`, to the workflow inputs. (`[pipelines/matrix/templates/argo_wf_spec.tmplR98](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R98)`)

### Node trimming logic:

* Introduced logic to trim `kedro_nodes` to a maximum of 36 characters and remove trailing underscores, dashes, or dots before assigning it to `trimmed_kedro_nodes`. (`[pipelines/matrix/templates/argo_wf_spec.tmplR352-R353](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R352-R353)`)

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [X] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
