### PR TITLE
Trim kedro nodes to 63 not 36

### DIFF
--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -350,7 +350,7 @@ spec:
           - name: kedro_nodes
             value: {{ task.nodes }}
           - name: trimmed_kedro_nodes
-            value: {{ task.nodes[:36].rstrip('_-.').replace(',', '-') }}
+            value: {{ task.nodes[:63].rstrip('_-.').replace(',', '-') }}
           - name: num_gpus
             value: {{ task.resources.num_gpus }}
           - name: memory_request


### PR DESCRIPTION
# Description of the changes <!-- required! -->

The previous PR trimmed kedro_nodes to 36 characters while the maximum allowed is 63

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
