### PR TITLE
Fix errors length error with Kubernetes

### DIFF
--- a/pipelines/matrix/src/matrix/utils/kubernetes.py
+++ b/pipelines/matrix/src/matrix/utils/kubernetes.py
@@ -115,7 +115,7 @@ def apply(namespace, file_path: Path, verbose: bool):
     `kubectl apply -f <file_path> -n <namespace>` will make the template available as a resource (but will not create any other resources, and will not trigger the workshop).
     """
 
-    cmd = f"kubectl apply -f {file_path} -n {namespace}"
+    cmd = f"kubectl create -f {file_path} -n {namespace}"
     run_subprocess(
         cmd,
         check=True,


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- The WorkflowTemplate "attempt-1-2773c47d" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
Error during submission: Command 'kubectl apply -f /Users/alexei/Documents/repos/matrix/pipelines/matrix/templates/argo-workflow-template.yml -n argo-workflows' returned non-zero exit status 1.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
