### PR TITLE
Add approval checks for CI workflows that uses self hosted runner

### DIFF
--- a/.github/workflows/matrix-ci-approval-trigger.yml
+++ b/.github/workflows/matrix-ci-approval-trigger.yml
@@ -1,0 +1,32 @@
+# This workflow triggers the main CI workflow when PR is approved
+# It acts as a simple approval-based trigger for the matrix CI
+
+name: Matrix CI Approval Trigger
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+  push:
+    branches:
+      - main
+    paths: 
+      - pipelines/matrix/**
+      - .github/workflows/matrix-ci*.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Trigger the main CI workflow with approval condition
+  trigger_ci:
+    uses: ./.github/workflows/matrix-ci.yml
+    # Pass the main + approved condition as input
+    with:
+      run_on_main_approved: ${{ github.ref == 'refs/heads/main' && github.event.review.state == 'approved' }}
+    secrets: inherit
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      pull-requests: 'read'

--- a/.github/workflows/matrix-ci-approval-trigger.yml
+++ b/.github/workflows/matrix-ci-approval-trigger.yml
@@ -40,6 +40,7 @@ jobs:
       run_on_main_approved: ${{ github.ref == 'refs/heads/main' && github.event.review.state == 'approved' }}
     secrets: inherit
     permissions:
-      contents: 'read'
-      id-token: 'write'
-      pull-requests: 'read'
+      contents: read
+      id-token: write
+      pull-requests: read
+      packages: write

--- a/.github/workflows/matrix-ci-approval-trigger.yml
+++ b/.github/workflows/matrix-ci-approval-trigger.yml
@@ -34,10 +34,9 @@ concurrency:
 jobs:
   # Trigger the main CI workflow with approval condition
   trigger_ci:
+    if: github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
     uses: ./.github/workflows/matrix-ci.yml
     # Pass the main + approved condition as input
-    with:
-      run_on_main_approved: ${{ github.ref == 'refs/heads/main' && github.event.review.state == 'approved' }}
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/matrix-ci-approval-trigger.yml
+++ b/.github/workflows/matrix-ci-approval-trigger.yml
@@ -4,15 +4,28 @@
 name: Matrix CI Approval Trigger
 
 on:
-  pull_request_review:
-    types: [submitted]
+
+  pull_request:
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - main
+      - develop
+    # from https://github.com/reviewdog/action-eslint/issues/29#issuecomment-985939887
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
   push:
     branches:
       - main
     paths: 
       - pipelines/matrix/**
-      - .github/workflows/matrix-ci*.yml
+      - .github/workflows/matrix-ci.yml
+
+  pull_request_review:
+    types: [submitted]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/matrix-ci-approval-trigger.yml
+++ b/.github/workflows/matrix-ci-approval-trigger.yml
@@ -36,7 +36,6 @@ jobs:
   trigger_ci:
     if: github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
     uses: ./.github/workflows/matrix-ci.yml
-    # Pass the main + approved condition as input
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -65,6 +65,7 @@ jobs:
     runs-on: 'self-hosted'
     needs: [paths_filter]
     if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main')
+
     outputs:
       status: ${{ steps.finally.outputs.status }}
 
@@ -115,6 +116,7 @@ jobs:
   matrix_ci_check:
     name: Matrix CI PR Check
     runs-on:  'self-hosted'
+    if: always()
     needs: [paths_filter, ci]
     steps:
       - if: ${{ needs.paths_filter.outputs.changed == 'true' && needs.ci.outputs.status == 'failure' }}
@@ -125,6 +127,7 @@ jobs:
 
   push_image:
     needs: [ci]
+    if: github.ref == 'refs/heads/main'
     runs-on: 'self-hosted'
     environment: dev
     permissions: write-all
@@ -165,7 +168,7 @@ jobs:
     needs: [ci, push_image]
     # This condition ensures it runs only if any previous job fails
     # we notify on main branches only
-    if: failure()
+    if: failure() && github.ref == 'refs/heads/main' 
     runs-on: "self-hosted"
     steps:
       - name: Post to a Slack channel

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -130,7 +130,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: 'self-hosted'
     environment: dev
-    permissions: write-all
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     defaults:
       run:
         working-directory: ./pipelines/matrix

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -14,19 +14,17 @@
 name: CI pipeline
 
 on:
-  pull_request_review:
-    types: [submitted]
-
-  push:
-    branches:
-      - main
-    paths: 
-      - pipelines/matrix/**
-      - .github/workflows/matrix-ci.yml
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      run_on_main_approved:
+        description: 'Whether this is running on main branch with approved review'
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      ci_status:
+        description: 'Status of the CI run'
+        value: ${{ jobs.ci.outputs.status }}
 
 env:
   TQDM_DISABLE: 1
@@ -37,7 +35,7 @@ jobs:
   # FUTURE eventually github will likely fix this
   # https://github.com/orgs/community/discussions/26698
   paths_filter:
-    if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
+    if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main'
     runs-on: 'ubuntu-latest'
     permissions: 
       pull-requests: read
@@ -57,13 +55,13 @@ jobs:
           filters: |
             src:
               - pipelines/matrix/**
-              - .github/workflows/matrix-ci.yml
+              - .github/workflows/matrix-ci*.yml
 
   ci:
     runs-on: 'self-hosted'
     needs: [paths_filter]
     # Only run if PR is approved, not just opened or synchronized
-    if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false && github.event.pull_request.mergeable_state == 'clean' && github.event.pull_request.state == 'open' || github.ref == 'refs/heads/main') && github.event.review.state == 'approved'
+    if: needs.paths_filter.outputs.changed == 'true'
     outputs:
       status: ${{ steps.finally.outputs.status }}
 
@@ -109,6 +107,7 @@ jobs:
       - id: finally
         if: failure()
         run: echo "status=failure" >> "$GITHUB_OUTPUT"
+
   # we use this check as required in our PRs to ensure that CI runs but only for our paths. 
   matrix_ci_check:
     name: Matrix CI PR Check
@@ -120,11 +119,10 @@ jobs:
         run: echo "CI failed, we are exiting" && exit 1
       - run: echo "Either no files were changed or we had happy CI, continuing"
 
-      
+
 
   push_image:
     needs: [ci]
-    if: github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
     runs-on: 'self-hosted'
     environment: dev
     permissions: write-all
@@ -165,7 +163,7 @@ jobs:
     needs: [ci, push_image]
     # This condition ensures it runs only if any previous job fails
     # we notify on main branches only
-    if: failure() && github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
+    if: failure()
     runs-on: "self-hosted"
     steps:
       - name: Post to a Slack channel

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -60,7 +60,7 @@ jobs:
   ci:
     runs-on: 'self-hosted'
     needs: [paths_filter]
-    if: needs.paths_filter.outputs.changed == 'true'
+    if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main')
     outputs:
       status: ${{ steps.finally.outputs.status }}
 

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -26,6 +26,10 @@ on:
         description: 'Status of the CI run'
         value: ${{ jobs.ci.outputs.status }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TQDM_DISABLE: 1
 

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -14,6 +14,8 @@
 name: CI pipeline
 
 on:
+  pull_request_review:
+    types: [submitted]
   pull_request:
     # Sequence of patterns matched against refs/heads
     branches:
@@ -71,8 +73,8 @@ jobs:
   ci:
     runs-on: 'self-hosted'
     needs: [paths_filter]
-    if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main')
-    
+    # Only run if PR is approved, not just opened or synchronized
+    if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false && github.event.pull_request.mergeable_state == 'clean' && github.event.pull_request.state == 'open' || github.ref == 'refs/heads/main') && github.event.review.state == 'approved'
     outputs:
       status: ${{ steps.finally.outputs.status }}
 
@@ -122,7 +124,7 @@ jobs:
   matrix_ci_check:
     name: Matrix CI PR Check
     runs-on:  'self-hosted'
-    if: always()
+    if: github.event.review.state == 'approved'
     needs: [paths_filter, ci]
     steps:
       - if: ${{ needs.paths_filter.outputs.changed == 'true' && needs.ci.outputs.status == 'failure' }}
@@ -133,7 +135,7 @@ jobs:
 
   push_image:
     needs: [ci]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
     runs-on: 'self-hosted'
     environment: dev
     permissions: write-all
@@ -174,7 +176,7 @@ jobs:
     needs: [ci, push_image]
     # This condition ensures it runs only if any previous job fails
     # we notify on main branches only
-    if: failure() && github.ref == 'refs/heads/main' 
+    if: failure() && github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
     runs-on: "self-hosted"
     steps:
       - name: Post to a Slack channel

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -27,7 +27,7 @@ on:
         value: ${{ jobs.ci.outputs.status }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: matrix-ci-reusable-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -16,17 +16,6 @@ name: CI pipeline
 on:
   pull_request_review:
     types: [submitted]
-  pull_request:
-    # Sequence of patterns matched against refs/heads
-    branches:
-      - main
-      - develop
-    # from https://github.com/reviewdog/action-eslint/issues/29#issuecomment-985939887
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 
   push:
     branches:
@@ -48,7 +37,7 @@ jobs:
   # FUTURE eventually github will likely fix this
   # https://github.com/orgs/community/discussions/26698
   paths_filter:
-    if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main'
+    if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
     runs-on: 'ubuntu-latest'
     permissions: 
       pull-requests: read

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -60,7 +60,6 @@ jobs:
   ci:
     runs-on: 'self-hosted'
     needs: [paths_filter]
-    # Only run if PR is approved, not just opened or synchronized
     if: needs.paths_filter.outputs.changed == 'true'
     outputs:
       status: ${{ steps.finally.outputs.status }}
@@ -112,7 +111,6 @@ jobs:
   matrix_ci_check:
     name: Matrix CI PR Check
     runs-on:  'self-hosted'
-    if: github.event.review.state == 'approved'
     needs: [paths_filter, ci]
     steps:
       - if: ${{ needs.paths_filter.outputs.changed == 'true' && needs.ci.outputs.status == 'failure' }}

--- a/.github/workflows/moa-ci.yml
+++ b/.github/workflows/moa-ci.yml
@@ -1,16 +1,21 @@
 name: MoA CI pipline
 
 on:
-    pull_request_review:
-      types: [submitted]
-  
-    push:
-      branches:
-        - main
-      paths: 
-        - services/moa_visualizer/**
-        - .github/workflows/moa-ci.yml
+  workflow_call:
+    inputs:
+      run_on_main_approved:
+        description: 'Whether this is running on main branch with approved review'
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      ci_status:
+        description: 'Status of the CI run'
+        value: ${{ jobs.ci.outputs.status }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # leveraging a paths-filter approach to be able to make this run required for all PRs while still
@@ -18,7 +23,7 @@ jobs:
   # FUTURE eventually github will likely fix this
   # https://github.com/orgs/community/discussions/26698
   paths_filter:
-    if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
+    if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main'
     runs-on: 'ubuntu-latest'
     permissions: 
       pull-requests: read
@@ -43,7 +48,7 @@ jobs:
   ci:
     runs-on:  'self-hosted'
     needs: [paths_filter]
-    if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main') && github.event.review.state == 'approved'
+    if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main')
     defaults:
       run:
         working-directory: ./services/moa_visualizer
@@ -57,7 +62,7 @@ jobs:
 
   push_image:
       needs: [ci]
-      if: github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
+      if: github.ref == 'refs/heads/main'
       runs-on: 'self-hosted'
       environment: dev
       permissions: write-all

--- a/.github/workflows/moa-ci.yml
+++ b/.github/workflows/moa-ci.yml
@@ -18,7 +18,7 @@ jobs:
   # FUTURE eventually github will likely fix this
   # https://github.com/orgs/community/discussions/26698
   paths_filter:
-    if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main'
+    if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
     runs-on: 'ubuntu-latest'
     permissions: 
       pull-requests: read

--- a/.github/workflows/moa-ci.yml
+++ b/.github/workflows/moa-ci.yml
@@ -1,6 +1,8 @@
 name: MoA CI pipline
 
 on:
+    pull_request_review:
+      types: [submitted]
     pull_request:
       # Sequence of patterns matched against refs/heads
       branches:
@@ -53,7 +55,7 @@ jobs:
   ci:
     runs-on:  'self-hosted'
     needs: [paths_filter]
-    if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main')
+    if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main') && github.event.review.state == 'approved'
     defaults:
       run:
         working-directory: ./services/moa_visualizer
@@ -67,7 +69,7 @@ jobs:
 
   push_image:
       needs: [ci]
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' && github.event.review.state == 'approved'
       runs-on: 'self-hosted'
       environment: dev
       permissions: write-all

--- a/.github/workflows/moa-ci.yml
+++ b/.github/workflows/moa-ci.yml
@@ -3,18 +3,6 @@ name: MoA CI pipline
 on:
     pull_request_review:
       types: [submitted]
-    pull_request:
-      # Sequence of patterns matched against refs/heads
-      branches:
-        - main
-      types:
-        - opened
-        - reopened
-        - synchronize
-        - ready_for_review
-      paths: 
-        - services/moa_visualizer/**
-        - .github/workflows/moa-ci.yml
   
     push:
       branches:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

This pull request updates the CI workflow configuration for both the main and MoA pipelines to ensure jobs only run after a pull request has been explicitly approved by a reviewer. This change helps prevent CI jobs from running on unapproved or draft pull requests, improving the reliability and relevance of CI runs on the self-hosted runner (which runs in GCP).

**CI trigger and job execution changes:**

* Added the `pull_request_review` event trigger to both `.github/workflows/matrix-ci.yml` and `.github/workflows/moa-ci.yml`, specifically for submitted reviews. [[1]](diffhunk://#diff-8d881a1a9ff73df2434ddb0b3c5f7edaadeee1d4be5cfb8a1643f3b90b8523edR17-R18) [[2]](diffhunk://#diff-37207dd5a766f634e031818afc684a4c68a008cfa6cf2e3e1ad7c403005ae395R4-R5)
* Updated the `ci` job conditions in both workflows to require that the pull request review state is `approved` before running CI jobs. [[1]](diffhunk://#diff-8d881a1a9ff73df2434ddb0b3c5f7edaadeee1d4be5cfb8a1643f3b90b8523edL74-R77) [[2]](diffhunk://#diff-37207dd5a766f634e031818afc684a4c68a008cfa6cf2e3e1ad7c403005ae395L56-R58)
* Changed the `matrix_ci_check` job in `.github/workflows/matrix-ci.yml` to only run when the review state is `approved`.
* Modified the `push_image` job in both workflows to only run when the review state is `approved` and the branch is `main`. [[1]](diffhunk://#diff-8d881a1a9ff73df2434ddb0b3c5f7edaadeee1d4be5cfb8a1643f3b90b8523edL136-R138) [[2]](diffhunk://#diff-37207dd5a766f634e031818afc684a4c68a008cfa6cf2e3e1ad7c403005ae395L70-R72)
* Updated the failure notification job in `.github/workflows/matrix-ci.yml` to only notify on failures for approved pull requests on the main branch.

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
