### PR TITLE
Add ARGO configuration to core stability pipeline

### DIFF
--- a/pipelines/matrix/src/matrix/pipelines/evaluation/pipeline.py
+++ b/pipelines/matrix/src/matrix/pipelines/evaluation/pipeline.py
@@ -76,6 +76,7 @@ def _create_core_stability_pipeline(
                 ],
                 outputs=f"evaluation.{matrix_input}.fold_{fold_main}.fold_{fold_to_compare}.{evaluation}.model_stability_output.result",
                 name=f"{matrix_input}.calculate_{fold_main}_{fold_to_compare}_{evaluation}",
+                argo_config=ARGO_NODE_MEDIUM_MATRIX_GENERATION,
             ),
         ]
     else:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request introduces a minor configuration update to the core stability pipeline in `pipeline.py`. The change sets a specific Argo node configuration for the pipeline step to ensure it runs with the desired resource profile.

* Pipeline configuration: The `argo_config` parameter is now explicitly set to `ARGO_NODE_MEDIUM_MATRIX_GENERATION` for the `calculate_{fold_main}_{fold_to_compare}_{evaluation}` step in the `_create_core_stability_pipeline` function in `pipelines/matrix/src/matrix/pipelines/evaluation/pipeline.py`.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
