### PR TITLE
constraint error running neo4j community

### DIFF
--- a/pipelines/matrix/conf/base/embeddings/catalog.yml
+++ b/pipelines/matrix/conf/base/embeddings/catalog.yml
@@ -42,7 +42,6 @@ embeddings.tmp.input_nodes:
     # `entity` label on which we generate a unique constraint. This has the side-effect
     # that an index is created which allows for quick edge inserts down the line.
     # https://neo4j.com/docs/cypher-manual/current/constraints/
-    # mode: overwrite
     script: >
       CREATE CONSTRAINT IF NOT EXISTS FOR (n:Entity) REQUIRE n.id IS UNIQUE;
     query: > 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request makes a minor change to the `pipelines/matrix/conf/base/embeddings/catalog.yml` configuration by removing the `mode: overwrite` line from the `embeddings.tmp.input_nodes` section. This value is unnecessary and breaks Neo4j on the community edition that we have. the `embeddings` pipeline spins up neo4j as a sidecar and does not require overwrite as the neo4j is empty.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
```bash
DatasetError: Failed while saving data to dataset Neo4JSparkDataset(file_format=parquet, filepath=filepath, load_args={}, save_args={'query': CREATE (n:Entity {id: event.id, pca_embedding: event.pca_embedding}) WITH event, n CALL apoc.create.addLabels(n, event.labels) YIELD node RETURN node
, 'script': CREATE CONSTRAINT IF NOT EXISTS FOR (n:Entity) REQUIRE n.id IS UNIQUE;
}).
{code: Neo.ClientError.Statement.UnsupportedAdministrationCommand} {message: Unsupported administration command: CREATE OR REPLACE DATABASE `analytics`}
```


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
