### PR TITLE
Hotfix/max payload should be string

### DIFF
--- a/infra/argo/applications/data-release/templates/DeployEventbus.yaml
+++ b/infra/argo/applications/data-release/templates/DeployEventbus.yaml
@@ -13,7 +13,7 @@ spec:
       auth: token
       # Increase max payload size to handle large workflow objects. Setting to 100MB
       # https://argoproj.github.io/argo-events/eventbus/stan/
-      maxPayload: "100MB"
+      maxPayload: "0"
 #      containerTemplate:
 #        resources:
 #          requests:

--- a/infra/argo/applications/data-release/templates/DeployEventbus.yaml
+++ b/infra/argo/applications/data-release/templates/DeployEventbus.yaml
@@ -11,9 +11,9 @@ spec:
       replicas: 3
       # Optional, authen strategy, "none" or "token", defaults to "none"
       auth: token
-      # Increase max payload size to handle large workflow objects. 0 means unlimited
+      # Increase max payload size to handle large workflow objects. Setting to 100MB
       # https://argoproj.github.io/argo-events/eventbus/stan/
-      maxPayload: 0
+      maxPayload: "100MB"
 #      containerTemplate:
 #        resources:
 #          requests:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request makes a minor update to the `DeployEventbus.yaml` configuration. The main change is setting the `maxPayload` value to the string `"0"` instead of the integer `0`, clarifying the configuration for handling large workflow objects.

- Configuration update:
  * Changed the `maxPayload` value from the integer `0` to the string `"0"` in the `DeployEventbus.yaml` template to clarify the payload size setting.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 
<img width="3875" height="1002" alt="Screenshot 2025-08-14 at 15 03 06" src="https://github.com/user-attachments/assets/6ba9cf73-5987-4043-8a03-98e29cb1b2aa" />



# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
