### PR TITLE
Only report failure if branch name is present

### DIFF
--- a/infra/modules/components/cloudbuild/slack_notifier/variable.tf
+++ b/infra/modules/components/cloudbuild/slack_notifier/variable.tf
@@ -13,7 +13,7 @@ variable "slack_webhook_url" {
 variable "cloud_build_event_filter" {
   description = "The CEL filter to apply to incoming Cloud Build events."
   type        = string
-  default     = "build.status in [Build.Status.FAILURE, Build.Status.TIMEOUT]"
+  default     = "'BRANCH_NAME' in build.substitutions && build.status in [Build.Status.FAILURE, Build.Status.TIMEOUT]"
 }
 
 variable "cloud_build_notifier_image" {


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request updates the default filter for incoming Cloud Build events in the Slack notifier module to ensure notifications are only sent for builds associated with a branch and that have failed or timed out.

- **Cloud Build Event Filtering:**
  * Updated the `cloud_build_event_filter` default value in `variable.tf` to only trigger notifications when `'BRANCH_NAME'` is present in `build.substitutions` and the build status is either `FAILURE` or `TIMEOUT`. This helps reduce noise by ignoring events not tied to a branch.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
