### PR TITLE
Add release history link to kg dashboard home page

### DIFF
--- a/services/kg_dashboard/pages/index.md
+++ b/services/kg_dashboard/pages/index.md
@@ -2,6 +2,12 @@
 title: KG Dashboard
 ---
 
+<div class="mb-4">
+  <a href="https://docs.dev.everycure.org/releases/release_history/" class="inline-flex items-center text-blue-600 hover:text-blue-800 text-sm">
+    ← Release History
+  </a>
+</div>
+
 <script context="module">
   import { getSourceColor } from './_lib/colors';
   


### PR DESCRIPTION
Adds a link to the release history page at the top of the dashboard home page, to make it easier to find other versions of the dashboard. 