### PR TITLE
Fix release history page and its generation

### DIFF
--- a/docs/scripts/changelog_gen.py
+++ b/docs/scripts/changelog_gen.py
@@ -3,6 +3,7 @@ that can immediately be referenced by the Releases page on the documentation
 website."""
 
 import json
+import re
 from pathlib import Path
 from typing import Dict, Iterable, Iterator, List
 
@@ -24,15 +25,24 @@ def list_json_files(changelog_abs_path: Path, filename_pattern: str = "v*_info.j
     return json_files
 
 
+def is_markdown_link(text):
+    """Check if string has the shape [*](*)"""
+    pattern = r"^\[.*?\]\(.*?\)$"
+    return bool(re.match(pattern, text))
+
+
 def format_values(loaded_files):
     link_tmpl = "[Link]({value})"
-    code_tmpl = "`{value}`"
+
+    link_columns = ["BigQuery", "KG dashboard", "MLFlow", "Code", "NodeNorm Endpoint"]
+    already_formatted_link_columns = ["NodeNorm Endpoint"]
+
     for file in loaded_files:
         for key, value in file.items():
-            if key.lower().endswith("link"):
+            if key in already_formatted_link_columns and is_markdown_link(value):
+                file[key] = value
+            elif key in link_columns:
                 file[key] = link_tmpl.format(value=value)
-            elif key.lower().endswith(("encoder", "estimator")):
-                file[key] = code_tmpl.format(value=value)
     return loaded_files
 
 

--- a/docs/src/releases/changelog_files/releases_aggregated.yaml
+++ b/docs/src/releases/changelog_files/releases_aggregated.yaml
@@ -1,202 +1,122 @@
 - Release Name: v0.9.0
   Datasets: "\u2023 rtx_kg2: `v2.10.0_validated`<br/>\u2023 robokop: `30fd1bfc18cd5ccb`"
-  BigQuery: https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_9_0
-  KG dashboard: https://data.dev.everycure.org/versions/v0.9.0/evidence/
-  MLFlow: https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/e839f0efb2a84996b0dc7ae397f295d1
-  Code: https://github.com/everycure-org/matrix/tree/v0.9.0
-  NodeNorm Endpoint: https://nodenormalization-sri.renci.org/1.5/get_normalized_nodes
-    (nodenorm-renci-2.3.23)
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_9_0)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.9.0/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/e839f0efb2a84996b0dc7ae397f295d1)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.9.0)'
+  NodeNorm Endpoint: '[nodenorm-renci-2.3.23](https://nodenormalization-sri.renci.org/1.5/get_normalized_nodes)'
 - Release Name: v0.8.0
   Datasets: "\u2023 rtx_kg2: `v2.10.0_validated`<br/>\u2023 robokop: `30fd1bfc18cd5ccb`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 embiology: `not included`<br/>\u2023 ec_medical_team:\
-    \ `20241031`<br/>\u2023 ec_clinical_trials: `not included`<br/>\u2023 drug_list:\
-    \ `not included`<br/>\u2023 disease_list: `not included`<br/>\u2023 gt: `not included`<br/>\u2023\
-    \ drugmech: `not included`<br/>\u2023 off_label: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_8_0)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/a346e54e8f884b598b1489427807692a)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.8.0)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  KG dashboard link: '[Link](https://data.dev.everycure.org/versions/v0.8.0/evidence/)'
+    \ ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_8_0)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.8.0/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/a346e54e8f884b598b1489427807692a)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.8.0)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.7.0
   Datasets: "\u2023 rtx_kg2: `v2.10.0_validated`<br/>\u2023 robokop: `30fd1bfc18cd5ccb`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 embiology: `not included`<br/>\u2023 ec_medical_team:\
-    \ `20241031`<br/>\u2023 ec_clinical_trials: `not included`<br/>\u2023 drug_list:\
-    \ `not included`<br/>\u2023 disease_list: `not included`<br/>\u2023 gt: `not included`<br/>\u2023\
-    \ drugmech: `not included`<br/>\u2023 off_label: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_7_0)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/fcfa60aeac13405295df07cef5f67fce)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.7.0)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  KG dashboard link: '[Link](https://data.dev.everycure.org/versions/v0.7.0/evidence/)'
+    \ ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_7_0)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.7.0/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/fcfa60aeac13405295df07cef5f67fce)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.7.0)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.6.0
   Datasets: "\u2023 rtx_kg2: `v2.10.0_validated`<br/>\u2023 robokop: `30fd1bfc18cd5ccb`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 embiology: `not included`<br/>\u2023 ec_medical_team:\
-    \ `20241031`<br/>\u2023 ec_clinical_trials: `not included`<br/>\u2023 drug_list:\
-    \ `not included`<br/>\u2023 disease_list: `not included`<br/>\u2023 gt: `not included`<br/>\u2023\
-    \ drugmech: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_6_0)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/0fc667d72cff4e36817a35e8fb9a21dd)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.6.0)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  KG dashboard link: '[Link](https://data.dev.everycure.org/versions/v0.6.0/evidence/)'
+    \ ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_6_0)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.6.0/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/0fc667d72cff4e36817a35e8fb9a21dd)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.6.0)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.5.3
   Datasets: "\u2023 rtx_kg2: `v2.10.0_validated`<br/>\u2023 robokop: `30fd1bfc18cd5ccb`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 ec_clinical_trials:\
-    \ `not included`<br/>\u2023 drug_list: `not included`<br/>\u2023 disease_list:\
-    \ `not included`<br/>\u2023 gt: `not included`<br/>\u2023 drugmech: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_5_3)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/49a93008ff4142d182d5927e31f226f7)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.5.3)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  KG dashboard link: '[Link](https://data.dev.everycure.org/versions/v0.5.3/evidence/)'
+    \ ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_5_3)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.5.3/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/49a93008ff4142d182d5927e31f226f7)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.5.3)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.5.2
   Datasets: "\u2023 rtx_kg2: `v2.10.0`<br/>\u2023 robokop: `c5ec1f282158182f`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 ec_clinical_trials:\
-    \ `not included`<br/>\u2023 drug_list: `not included`<br/>\u2023 disease_list:\
-    \ `not included`<br/>\u2023 gt: `not included`<br/>\u2023 drugmech: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_5_2)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/8b4f3b8e6199408384160c32b03764b2)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.5.2)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  KG dashboard link: '[Link](https://data.dev.everycure.org/versions/v0.5.2/evidence/)'
+    \ ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_5_2)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.5.2/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/8b4f3b8e6199408384160c32b03764b2)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.5.2)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.4.5
-  Datasets: "\u2023 rtx_kg2: `v2.10.0`<br/>\u2023 robokop: `not included`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 ec_clinical_trials:\
-    \ `not included`<br/>\u2023 drug_list: `not included`<br/>\u2023 disease_list:\
-    \ `not included`<br/>\u2023 gt: `not included`<br/>\u2023 drugmech: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_5)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/20032/runs/0c34da8d4c3c42edacf215c6a2e6492c)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.5)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  KG dashboard link: '[Link](https://data.dev.everycure.org/versions/v0.4.5/evidence/)'
+  Datasets: "\u2023 rtx_kg2: `v2.10.0`<br/>\u2023 ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_5)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.4.5/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/20032/runs/0c34da8d4c3c42edacf215c6a2e6492c)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.5)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.4.4
-  Datasets: "\u2023 rtx_kg2: `v2.10.0`<br/>\u2023 robokop: `not included`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 ec_clinical_trials:\
-    \ `not included`<br/>\u2023 drug_list: `not included`<br/>\u2023 disease_list:\
-    \ `not included`<br/>\u2023 gt: `not included`<br/>\u2023 drugmech: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_4)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/19730/runs/16750d42311045f782dfd4ccbde5fd99)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.4)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  KG dashboard link: '[Link](https://data.dev.everycure.org/versions/v0.4.4/evidence/)'
+  Datasets: "\u2023 rtx_kg2: `v2.10.0`<br/>\u2023 ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_4)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.4.4/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/19730/runs/16750d42311045f782dfd4ccbde5fd99)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.4)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.4.3
   Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `c5ec1f282158182f`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 ec_clinical_trials:\
-    \ `not included`<br/>\u2023 drug_list: `not included`<br/>\u2023 disease_list:\
-    \ `not included`<br/>\u2023 gt: `not included`<br/>\u2023 drugmech: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_3)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/bb5c1fe7e13b4206a23861feb671ae41)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.3)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  KG dashboard link: '[Link](https://data.dev.everycure.org/versions/v0.4.3/evidence/)'
+    \ ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_3)'
+  KG dashboard: '[Link](https://data.dev.everycure.org/versions/v0.4.3/evidence/)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/bb5c1fe7e13b4206a23861feb671ae41)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.3)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.4.1
-  Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `not included`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 ec_clinical_trials:\
-    \ `not included`<br/>\u2023 drug_list: `not included`<br/>\u2023 disease_list:\
-    \ `not included`<br/>\u2023 gt: `not included`<br/>\u2023 drugmech: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_1)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18732/runs/f44035c29f2e4fd19589faad4b48bd82)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.1)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
+  Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_1)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18732/runs/f44035c29f2e4fd19589faad4b48bd82)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.1)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.4.0
   Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `c5ec1f282158182f`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 ec_clinical_trials:\
-    \ `not included`<br/>\u2023 drug_list: `not included`<br/>\u2023 disease_list:\
-    \ `not included`<br/>\u2023 gt: `not included`<br/>\u2023 drugmech: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_0)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18678/runs/60f16dbd0c6a4c43935510ce8112a338)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.0)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
+    \ ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_0)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/18678/runs/60f16dbd0c6a4c43935510ce8112a338)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.4.0)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.3.6
-  Datasets: "\u2023 rtx_kg2: `not included`<br/>\u2023 robokop: `c5ec1f282158182f`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 drugmech:\
-    \ `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_6)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/17938/runs/855f04b2ae2543baa024e6f77c118ced)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.3.6)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
+  Datasets: "\u2023 robokop: `c5ec1f282158182f`<br/>\u2023 ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_6)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/17938/runs/855f04b2ae2543baa024e6f77c118ced)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.3.6)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.3.5
-  Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `not included`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 drugmech:\
-    \ `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_5)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/17772/runs/b9836a192d984963a7d93f426174561d)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.3.5)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
+  Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_5)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/17772/runs/b9836a192d984963a7d93f426174561d)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.3.5)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.3.4
   Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `c5ec1f282158182f`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `20241031`<br/>\u2023 drugmech:\
-    \ `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_4)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/17727/runs/cff19c72d1284511af6364c019abcc71)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.3.4)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
+    \ ec_medical_team: `20241031`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_4)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/17727/runs/cff19c72d1284511af6364c019abcc71)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.3.4)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.3.0
-  Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `c5ec1f282158182f`<br/>\u2023\
-    \ spoke: `not included`<br/>\u2023 ec_medical_team: `not included`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_0)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/13754/runs/0f46e1ba8e6743f5a55c4dc140429373)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.3.0)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
+  Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `c5ec1f282158182f`"
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_0)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/13754/runs/0f46e1ba8e6743f5a55c4dc140429373)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.3.0)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.2.5
   Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `c5ec1f282158182f`<br/>\u2023\
     \ ec_medical_team: `20241031`"
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSGraphSage`'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/4750/runs/767f3ff5e1f94a62a543cb8e5ddde2d5)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.2.5)'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_2_5)'
-  Neo4j Link: '[Link](coming soon!)'
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_2_5)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/4750/runs/767f3ff5e1f94a62a543cb8e5ddde2d5)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.2.5)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
 - Release Name: v0.2.3
   Datasets: "\u2023 rtx_kg2: `v2.7.3`<br/>\u2023 robokop: `c5ec1f282158182f`<br/>\u2023\
     \ ec_medical_team: `20241031`"
-  Topological Estimator: '`matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec`'
-  Embeddings Encoder: '`text-embedding-3-small`'
-  BigQuery Link: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_2_3)'
-  MLFlow Link: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/10804/runs/d71c046bf3fa49b9818a101be830e6f8)'
-  Code Link: '[Link](https://github.com/everycure-org/matrix/tree/v0.2.3)'
-  Neo4j Link: '[Link](coming soon!)'
-  NodeNorm Endpoint Link: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'
+  BigQuery: '[Link](https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_2_3)'
+  KG dashboard: '[Link](null)'
+  MLFlow: '[Link](https://mlflow.platform.dev.everycure.org/#/experiments/10804/runs/d71c046bf3fa49b9818a101be830e6f8)'
+  Code: '[Link](https://github.com/everycure-org/matrix/tree/v0.2.3)'
+  NodeNorm Endpoint: '[Link](https://nodenorm.transltr.io/1.5/get_normalized_nodes)'

--- a/docs/src/releases/changelog_files/v0.2.3_info.json
+++ b/docs/src/releases/changelog_files/v0.2.3_info.json
@@ -5,11 +5,9 @@
     "robokop": "c5ec1f282158182f",
     "ec_medical_team": 20241031
   },
-  "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec",
-  "Embeddings Encoder": "text-embedding-3-small",
-  "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_2_3",
-  "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/10804/runs/d71c046bf3fa49b9818a101be830e6f8",
-  "Code Link": "https://github.com/everycure-org/matrix/tree/v0.2.3",
-  "Neo4j Link": "coming soon!",
-  "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_2_3",
+  "KG dashboard": "null",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/10804/runs/d71c046bf3fa49b9818a101be830e6f8",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.2.3",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
 }

--- a/docs/src/releases/changelog_files/v0.2.5_info.json
+++ b/docs/src/releases/changelog_files/v0.2.5_info.json
@@ -1,13 +1,12 @@
-{"Release Name": "v0.2.5",
+{
+  "Release Name": "v0.2.5",
   "Datasets": {
     "rtx_kg2": "v2.7.3",
     "robokop": "c5ec1f282158182f",
     "ec_medical_team": 20241031
   },
-  "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes",
-  "Embeddings Encoder": "text-embedding-3-small",
-  "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSGraphSage",
-  "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/4750/runs/767f3ff5e1f94a62a543cb8e5ddde2d5",
-  "Code Link": "https://github.com/everycure-org/matrix/tree/v0.2.5",
-  "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_2_5",
-  "Neo4j Link": "coming soon!"}
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_2_5",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/4750/runs/767f3ff5e1f94a62a543cb8e5ddde2d5",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.2.5",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.3.0_info.json
+++ b/docs/src/releases/changelog_files/v0.3.0_info.json
@@ -1,1 +1,11 @@
-{"Release Name": "v0.3.0", "Datasets": {"rtx_kg2": "v2.7.3", "robokop": "c5ec1f282158182f", "spoke": "not included", "ec_medical_team": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_0", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/13754/runs/0f46e1ba8e6743f5a55c4dc140429373", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.3.0", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"}
+{
+  "Release Name": "v0.3.0",
+  "Datasets": {
+    "rtx_kg2": "v2.7.3",
+    "robokop": "c5ec1f282158182f"
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_0",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/13754/runs/0f46e1ba8e6743f5a55c4dc140429373",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.3.0",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.3.4_info.json
+++ b/docs/src/releases/changelog_files/v0.3.4_info.json
@@ -1,1 +1,12 @@
-{"Release Name": "v0.3.4", "Datasets": {"rtx_kg2": "v2.7.3", "robokop": "c5ec1f282158182f", "spoke": "not included", "ec_medical_team": 20241031, "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_4", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/17727/runs/cff19c72d1284511af6364c019abcc71", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.3.4", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"}
+{
+  "Release Name": "v0.3.4",
+  "Datasets": {
+    "rtx_kg2": "v2.7.3",
+    "robokop": "c5ec1f282158182f",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_4",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/17727/runs/cff19c72d1284511af6364c019abcc71",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.3.4",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.3.5_info.json
+++ b/docs/src/releases/changelog_files/v0.3.5_info.json
@@ -1,1 +1,11 @@
-{"Release Name": "v0.3.5", "Datasets": {"rtx_kg2": "v2.7.3", "robokop": "not included", "spoke": "not included", "ec_medical_team": 20241031, "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_5", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/17772/runs/b9836a192d984963a7d93f426174561d", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.3.5", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"}
+{
+  "Release Name": "v0.3.5",
+  "Datasets": {
+    "rtx_kg2": "v2.7.3",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_5",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/17772/runs/b9836a192d984963a7d93f426174561d",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.3.5",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.3.6_info.json
+++ b/docs/src/releases/changelog_files/v0.3.6_info.json
@@ -1,1 +1,11 @@
-{"Release Name": "v0.3.6", "Datasets": {"rtx_kg2": "not included", "robokop": "c5ec1f282158182f", "spoke": "not included", "ec_medical_team": 20241031, "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_6", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/17938/runs/855f04b2ae2543baa024e6f77c118ced", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.3.6", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"}
+{
+  "Release Name": "v0.3.6",
+  "Datasets": {
+    "robokop": "c5ec1f282158182f",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_3_6",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/17938/runs/855f04b2ae2543baa024e6f77c118ced",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.3.6",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.4.0_info.json
+++ b/docs/src/releases/changelog_files/v0.4.0_info.json
@@ -1,1 +1,12 @@
-{"Release Name": "v0.4.0", "Datasets": {"rtx_kg2": "v2.7.3", "robokop": "c5ec1f282158182f", "spoke": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_0", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/18678/runs/60f16dbd0c6a4c43935510ce8112a338", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.4.0", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"}
+{
+  "Release Name": "v0.4.0",
+  "Datasets": {
+    "rtx_kg2": "v2.7.3",
+    "robokop": "c5ec1f282158182f",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_0",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18678/runs/60f16dbd0c6a4c43935510ce8112a338",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.4.0",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.4.1_info.json
+++ b/docs/src/releases/changelog_files/v0.4.1_info.json
@@ -1,1 +1,11 @@
-{"Release Name": "v0.4.1", "Datasets": {"rtx_kg2": "v2.7.3", "robokop": "not included", "spoke": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_1", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/18732/runs/f44035c29f2e4fd19589faad4b48bd82", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.4.1", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"}
+{
+  "Release Name": "v0.4.1",
+  "Datasets": {
+    "rtx_kg2": "v2.7.3",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_1",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18732/runs/f44035c29f2e4fd19589faad4b48bd82",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.4.1",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.4.3_info.json
+++ b/docs/src/releases/changelog_files/v0.4.3_info.json
@@ -1,1 +1,13 @@
-{"Release Name": "v0.4.3", "Datasets": {"rtx_kg2": "v2.7.3", "robokop": "c5ec1f282158182f", "spoke": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_3", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/bb5c1fe7e13b4206a23861feb671ae41", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.4.3", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes", "KG dashboard link": "https://data.dev.everycure.org/versions/v0.4.3/evidence/"}
+{
+  "Release Name": "v0.4.3",
+  "Datasets": {
+    "rtx_kg2": "v2.7.3",
+    "robokop": "c5ec1f282158182f",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_3",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.4.3/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/bb5c1fe7e13b4206a23861feb671ae41",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.4.3",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.4.4_info.json
+++ b/docs/src/releases/changelog_files/v0.4.4_info.json
@@ -1,1 +1,12 @@
-{"Release Name": "v0.4.4", "Datasets": {"rtx_kg2": "v2.10.0", "robokop": "not included", "spoke": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_4", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/19730/runs/16750d42311045f782dfd4ccbde5fd99", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.4.4", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes", "KG dashboard link": "https://data.dev.everycure.org/versions/v0.4.4/evidence/"}
+{
+  "Release Name": "v0.4.4",
+  "Datasets": {
+    "rtx_kg2": "v2.10.0",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_4",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.4.4/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/19730/runs/16750d42311045f782dfd4ccbde5fd99",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.4.4",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.4.5_info.json
+++ b/docs/src/releases/changelog_files/v0.4.5_info.json
@@ -1,1 +1,12 @@
-{"Release Name": "v0.4.5", "Datasets": {"rtx_kg2": "v2.10.0", "robokop": "not included", "spoke": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_5", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/20032/runs/0c34da8d4c3c42edacf215c6a2e6492c", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.4.5", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes", "KG dashboard link": "https://data.dev.everycure.org/versions/v0.4.5/evidence/"}
+{
+  "Release Name": "v0.4.5",
+  "Datasets": {
+    "rtx_kg2": "v2.10.0",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_4_5",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.4.5/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/20032/runs/0c34da8d4c3c42edacf215c6a2e6492c",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.4.5",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.5.2_info.json
+++ b/docs/src/releases/changelog_files/v0.5.2_info.json
@@ -1,1 +1,13 @@
-{"Release Name": "v0.5.2", "Datasets": {"rtx_kg2": "v2.10.0", "robokop": "c5ec1f282158182f", "spoke": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_5_2", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/8b4f3b8e6199408384160c32b03764b2", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.5.2", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes", "KG dashboard link": "https://data.dev.everycure.org/versions/v0.5.2/evidence/"}
+{
+  "Release Name": "v0.5.2",
+  "Datasets": {
+    "rtx_kg2": "v2.10.0",
+    "robokop": "c5ec1f282158182f",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_5_2",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.5.2/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/8b4f3b8e6199408384160c32b03764b2",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.5.2",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.5.3_info.json
+++ b/docs/src/releases/changelog_files/v0.5.3_info.json
@@ -1,1 +1,13 @@
-{"Release Name": "v0.5.3", "Datasets": {"rtx_kg2": "v2.10.0_validated", "robokop": "30fd1bfc18cd5ccb", "spoke": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_5_3", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/49a93008ff4142d182d5927e31f226f7", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.5.3", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes", "KG dashboard link": "https://data.dev.everycure.org/versions/v0.5.3/evidence/"}
+{
+  "Release Name": "v0.5.3",
+  "Datasets": {
+    "rtx_kg2": "v2.10.0_validated",
+    "robokop": "30fd1bfc18cd5ccb",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_5_3",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.5.3/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/49a93008ff4142d182d5927e31f226f7",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.5.3",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.6.0_info.json
+++ b/docs/src/releases/changelog_files/v0.6.0_info.json
@@ -1,1 +1,13 @@
-{"Release Name": "v0.6.0", "Datasets": {"rtx_kg2": "v2.10.0_validated", "robokop": "30fd1bfc18cd5ccb", "spoke": "not included", "embiology": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_6_0", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/0fc667d72cff4e36817a35e8fb9a21dd", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.6.0", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes", "KG dashboard link": "https://data.dev.everycure.org/versions/v0.6.0/evidence/"}
+{
+  "Release Name": "v0.6.0",
+  "Datasets": {
+    "rtx_kg2": "v2.10.0_validated",
+    "robokop": "30fd1bfc18cd5ccb",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_6_0",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.6.0/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/0fc667d72cff4e36817a35e8fb9a21dd",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.6.0",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.7.0_info.json
+++ b/docs/src/releases/changelog_files/v0.7.0_info.json
@@ -1,1 +1,13 @@
-{"Release Name": "v0.7.0", "Datasets": {"rtx_kg2": "v2.10.0_validated", "robokop": "30fd1bfc18cd5ccb", "spoke": "not included", "embiology": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included", "off_label": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_7_0", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/fcfa60aeac13405295df07cef5f67fce", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.7.0", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes", "KG dashboard link": "https://data.dev.everycure.org/versions/v0.7.0/evidence/"}
+{
+  "Release Name": "v0.7.0",
+  "Datasets": {
+    "rtx_kg2": "v2.10.0_validated",
+    "robokop": "30fd1bfc18cd5ccb",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_7_0",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.7.0/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/fcfa60aeac13405295df07cef5f67fce",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.7.0",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.8.0_info.json
+++ b/docs/src/releases/changelog_files/v0.8.0_info.json
@@ -1,1 +1,13 @@
-{"Release Name": "v0.8.0", "Datasets": {"rtx_kg2": "v2.10.0_validated", "robokop": "30fd1bfc18cd5ccb", "spoke": "not included", "embiology": "not included", "ec_medical_team": 20241031, "ec_clinical_trials": "not included", "drug_list": "not included", "disease_list": "not included", "gt": "not included", "drugmech": "not included", "off_label": "not included"}, "Topological Estimator": "matrix.pipelines.embeddings.graph_algorithms.GDSNode2Vec", "Embeddings Encoder": "text-embedding-3-small", "BigQuery Link": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_8_0", "MLFlow Link": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/a346e54e8f884b598b1489427807692a", "Code Link": "https://github.com/everycure-org/matrix/tree/v0.8.0", "Neo4j Link": "coming soon!", "NodeNorm Endpoint Link": "https://nodenorm.transltr.io/1.5/get_normalized_nodes", "KG dashboard link": "https://data.dev.everycure.org/versions/v0.8.0/evidence/"}
+{
+  "Release Name": "v0.8.0",
+  "Datasets": {
+    "rtx_kg2": "v2.10.0_validated",
+    "robokop": "30fd1bfc18cd5ccb",
+    "ec_medical_team": 20241031
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_8_0",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.8.0/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/a346e54e8f884b598b1489427807692a",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.8.0",
+  "NodeNorm Endpoint": "https://nodenorm.transltr.io/1.5/get_normalized_nodes"
+}

--- a/docs/src/releases/changelog_files/v0.9.0_info.json
+++ b/docs/src/releases/changelog_files/v0.9.0_info.json
@@ -1,1 +1,12 @@
-{"Release Name": "v0.9.0", "Datasets": {"rtx_kg2": "v2.10.0_validated", "robokop": "30fd1bfc18cd5ccb"}, "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_9_0", "KG dashboard": "https://data.dev.everycure.org/versions/v0.9.0/evidence/", "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/e839f0efb2a84996b0dc7ae397f295d1", "Code": "https://github.com/everycure-org/matrix/tree/v0.9.0", "NodeNorm Endpoint": "https://nodenormalization-sri.renci.org/1.5/get_normalized_nodes (nodenorm-renci-2.3.23)"}
+{
+  "Release Name": "v0.9.0",
+  "Datasets": {
+    "rtx_kg2": "v2.10.0_validated",
+    "robokop": "30fd1bfc18cd5ccb"
+  },
+  "BigQuery": "https://console.cloud.google.com/bigquery?project=mtrx-hub-dev-3of&ws=!1m4!1m3!3m2!1smtrx-hub-dev-3of!2srelease_v0_9_0",
+  "KG dashboard": "https://data.dev.everycure.org/versions/v0.9.0/evidence/",
+  "MLFlow": "https://mlflow.platform.dev.everycure.org/#/experiments/18925/runs/e839f0efb2a84996b0dc7ae397f295d1",
+  "Code": "https://github.com/everycure-org/matrix/tree/v0.9.0",
+  "NodeNorm Endpoint": "[nodenorm-renci-2.3.23](https://nodenormalization-sri.renci.org/1.5/get_normalized_nodes)"
+}

--- a/pipelines/matrix/src/matrix/hooks.py
+++ b/pipelines/matrix/src/matrix/hooks.py
@@ -337,6 +337,12 @@ class ReleaseInfoHooks:
         return tmpl
 
     @staticmethod
+    def build_nodenorm_link() -> str:
+        normalizer = _parse_for_objects(ReleaseInfoHooks._params["integration"]["normalization"]["normalizer"])
+        tmpl = f"[{normalizer.version()}]({normalizer.endpoint})"
+        return tmpl
+
+    @staticmethod
     def build_mlflow_link() -> str:
         run_id = ReleaseInfoHooks._kedro_context.mlflow.tracking.run.id
         experiment_name = ReleaseInfoHooks._kedro_context.mlflow.tracking.experiment.name
@@ -361,7 +367,6 @@ class ReleaseInfoHooks:
 
     @staticmethod
     def extract_release_info(global_datasets: dict[str, Any]) -> dict[str, str]:
-        normalizer = _parse_for_objects(ReleaseInfoHooks._params["integration"]["normalization"]["normalizer"])
         info = {
             "Release Name": ReleaseInfoHooks._globals["versions"]["release"],
             "Datasets": global_datasets,
@@ -369,7 +374,7 @@ class ReleaseInfoHooks:
             "KG dashboard": ReleaseInfoHooks.build_kg_dashboard_link(),
             "MLFlow": ReleaseInfoHooks.build_mlflow_link(),
             "Code": ReleaseInfoHooks.build_code_link(),
-            "NodeNorm Endpoint": f"{normalizer.endpoint} ({normalizer.version()})",
+            "NodeNorm Endpoint": ReleaseInfoHooks.build_nodenorm_link(),
         }
         return info
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

The current release history page layout is broken as we have two different versions of release's format conflicting

## Old version 

<img width="1460" height="975" alt="image" src="https://github.com/user-attachments/assets/0bd98f59-5a46-4612-ba49-8212a32e3d76" />

This PR fixed the changelog files of all previous releases to match with the new pattern, and changes the way they are generated to make sure next releases follow this pattern.

## New version

<img width="1177" height="680" alt="image" src="https://github.com/user-attachments/assets/095c60bc-3a70-425e-a58f-cdfff6a67eb4" />

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
