### PR TITLE
Remove Local SSD and bumped disk size for GCP

### DIFF
--- a/docs/src/pipeline/debugging/debug_memory.md
+++ b/docs/src/pipeline/debugging/debug_memory.md
@@ -2,15 +2,15 @@
 
 ## Provisioning correct machine types
 
-Initially, we noticed the machine type was not being allocated. This due to the emphemeral storage requirements not being satisfied by any of the nodes.
+Initially, we noticed the machine type was not being allocated. This due to the ephemeral storage requirements not being satisfied by any of the nodes.
 
-> ✅ Adding local SSDs for emphemeral storage is supported through the [GCP Terraform module](https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/latest/submodules/private-cluster) using the `local_ssd_ephemeral_storage_count` attribute, but unfortunately is not available for all machine types. It turns out that the [N2D machine type](https://cloud.google.com/compute/docs/general-purpose-machines#n2d_machines) is one of the types that supports local SSDs. 
+> We have bumped the storage of the boot disk to 1 TB.
 
 ## Bumping memory spec
 
 Next, we noticed the Neo4J container going OOM. It turned out this was due to the hardcoded values in the Neo4J container, essentially capping it's resources.
 
-> ✅ This was solved by using the memory requirements as specifed in the pod's limits when setting up the environment variables for the Neo4J container.
+> ✅ This was solved by using the memory requirements as specified in the pod's limits when setting up the environment variables for the Neo4J container.
 
 ![](./assets/memory_usage.png)
 
@@ -31,7 +31,7 @@ To fix this, we applied 70% of the pod's memory request as the neo4j heap size s
 
 Moreover, we noticed a similar problem in the Spark configuration, where the the Spark configuration was hardcoded to a specific value.
 
-> ⛔️ This still requires a fix, in the ideal case we would expect the resouces defined in the node to correctly propagate.
+> ⛔️ This still requires a fix, in the ideal case we would expect the resources defined in the node to correctly propagate.
 
 ```yaml
 # spark.yaml

--- a/infra/modules/stacks/compute_cluster/gke.tf
+++ b/infra/modules/stacks/compute_cluster/gke.tf
@@ -8,20 +8,16 @@ locals {
   # node groups in 2 node locations, hence why the total amount of node groups.
   # https://console.cloud.google.com/kubernetes/clusters/details/us-central1/compute-cluster/logs/autoscaler_logs?chat=true&inv=1&invt=Abp5KQ&project=mtrx-hub-dev-3of
   n2d_node_pools = [for size in [8, 16, 32, 48, 64] : {
-    name           = "n2d-highmem-${size}-nodes"
-    machine_type   = "n2d-highmem-${size}"
-    node_locations = local.default_node_locations
-    min_count      = 0
-    max_count      = 10
-    # NOTE: Local SSDs are only available to certain node groups, and hence cannot be set for the
-    # reguluar n2 nodes. The statement below allocates 2 SSDs to the node, each having a capacity of 375G.
-    # https://cloud.google.com/compute/docs/general-purpose-machines#n2d-high-mem
-    local_ssd_ephemeral_storage_count = size < 64 ? 2 : 4
-    disk_type                         = "pd-ssd"
-    disk_size_gb                      = 200
-    enable_gcfs                       = true
-    enable_gvnic                      = true
-    initial_node_count                = 0
+    name               = "n2d-highmem-${size}-nodes"
+    machine_type       = "n2d-highmem-${size}"
+    node_locations     = local.default_node_locations
+    min_count          = 0
+    max_count          = 10
+    disk_type          = "pd-ssd"
+    disk_size_gb       = 1024
+    enable_gcfs        = true
+    enable_gvnic       = true
+    initial_node_count = 0
     }
   ]
 
@@ -63,21 +59,17 @@ locals {
 
   # Spot node pools for cost-effective compute workloads
   n2d_spot_node_pools = [for size in [8, 16, 32, 48, 64] : {
-    name           = "n2d-highmem-${size}-spot-nodes"
-    machine_type   = "n2d-highmem-${size}"
-    node_locations = local.default_node_locations
-    min_count      = 0
-    max_count      = 20 # Higher max count for spot instances
-    # NOTE: Local SSDs are only available to certain node groups, and hence cannot be set for the
-    # reguluar n2 nodes. The statement below allocates 2 SSDs to the node, each having a capacity of 375G.
-    # https://cloud.google.com/compute/docs/general-purpose-machines#n2d-high-mem
-    local_ssd_ephemeral_storage_count = size < 64 ? 2 : 4
-    disk_type                         = "pd-ssd"
-    disk_size_gb                      = 200
-    enable_gcfs                       = true
-    enable_gvnic                      = true
-    initial_node_count                = 0
-    spot                              = true
+    name               = "n2d-highmem-${size}-spot-nodes"
+    machine_type       = "n2d-highmem-${size}"
+    node_locations     = local.default_node_locations
+    min_count          = 0
+    max_count          = 20 # Higher max count for spot instances
+    disk_type          = "pd-ssd"
+    disk_size_gb       = 1024
+    enable_gcfs        = true
+    enable_gvnic       = true
+    initial_node_count = 0
+    spot               = true
     }
   ]
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request updates the GKE compute cluster configuration to increase boot disk storage to 1 TB and removes the local SSD that is not needed as increasing the boot disk size should be sufficient. We have also made related documentation improvements.

**Infrastructure changes:**
- Increased the `disk_size_gb` for both standard and spot node pools from 200GB to 1TB in `gke.tf` to provide more storage for each node. [[1]](diffhunk://#diff-c8752c8cb6721b71f98987ba4a697feccb364bde13760069bdae5d6b436cb40fL16-R17) [[2]](diffhunk://#diff-c8752c8cb6721b71f98987ba4a697feccb364bde13760069bdae5d6b436cb40fL71-R68)
- Removed the configuration and documentation for `local_ssd_ephemeral_storage_count`, shifting the storage strategy to rely solely on larger persistent disks. [[1]](diffhunk://#diff-c8752c8cb6721b71f98987ba4a697feccb364bde13760069bdae5d6b436cb40fL16-R17) [[2]](diffhunk://#diff-c8752c8cb6721b71f98987ba4a697feccb364bde13760069bdae5d6b436cb40fL71-R68)

**Documentation updates:**
- Updated `debug_memory.md` to describe the new approach of increasing the boot disk to 1TB instead of using local SSDs for ephemeral storage.
- Fixed minor typos and improved clarity in the documentation about memory and resource allocation. [[1]](diffhunk://#diff-1946d98ba1436cb26c782350f1763e9398a82da973b8c9ed546848cc58874491L5-R13) [[2]](diffhunk://#diff-1946d98ba1436cb26c782350f1763e9398a82da973b8c9ed546848cc58874491L34-R34)

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [X] Made corresponding changes to the documentation

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
