### PR TITLE
Bump `disk_size` of GKE Nodes to 1500 GB (1.5 TB) and disable image deletion policy

### DIFF
--- a/docs/src/pipeline/debugging/debug_memory.md
+++ b/docs/src/pipeline/debugging/debug_memory.md
@@ -4,7 +4,7 @@
 
 Initially, we noticed the machine type was not being allocated. This due to the ephemeral storage requirements not being satisfied by any of the nodes.
 
-> We have bumped the storage of the boot disk to 1 TB.
+> We have bumped the storage of the boot disk to 1.5 TB.
 
 ## Bumping memory spec
 

--- a/infra/modules/artifact_registry/main.tf
+++ b/infra/modules/artifact_registry/main.tf
@@ -4,9 +4,8 @@ resource "google_artifact_registry_repository" "this" {
   repository_id = var.repository_id
   format        = var.format
   description   = var.description
-
   # Dynamic block to create the DELETE policy only if delete_older_than_days is greater than 0.
-  dynamic "cleanup_policies" {
+  dynamic "cleanup_policy_dry_run" {
     for_each = var.delete_older_than_days != null ? [1] : []
     content {
       id     = "delete-old-artifacts"
@@ -19,7 +18,7 @@ resource "google_artifact_registry_repository" "this" {
   }
 
   # Policy to delete sample-run images after 1 day (configurable)
-  dynamic "cleanup_policies" {
+  dynamic "cleanup_policy_dry_run" {
     for_each = length(var.sample_run_tag_prefixes) > 0 ? [1] : []
     content {
       id     = "delete-sample-run-images"

--- a/infra/modules/artifact_registry/main.tf
+++ b/infra/modules/artifact_registry/main.tf
@@ -1,11 +1,12 @@
 resource "google_artifact_registry_repository" "this" {
-  project       = var.project_id
-  location      = var.location
-  repository_id = var.repository_id
-  format        = var.format
-  description   = var.description
+  project                = var.project_id
+  location               = var.location
+  repository_id          = var.repository_id
+  format                 = var.format
+  description            = var.description
+  cleanup_policy_dry_run = true
   # Dynamic block to create the DELETE policy only if delete_older_than_days is greater than 0.
-  dynamic "cleanup_policy_dry_run" {
+  dynamic "cleanup_policies" {
     for_each = var.delete_older_than_days != null ? [1] : []
     content {
       id     = "delete-old-artifacts"
@@ -18,7 +19,7 @@ resource "google_artifact_registry_repository" "this" {
   }
 
   # Policy to delete sample-run images after 1 day (configurable)
-  dynamic "cleanup_policy_dry_run" {
+  dynamic "cleanup_policies" {
     for_each = length(var.sample_run_tag_prefixes) > 0 ? [1] : []
     content {
       id     = "delete-sample-run-images"

--- a/infra/modules/stacks/compute_cluster/gke.tf
+++ b/infra/modules/stacks/compute_cluster/gke.tf
@@ -14,7 +14,7 @@ locals {
     min_count          = 0
     max_count          = 10
     disk_type          = "pd-ssd"
-    disk_size_gb       = 1024
+    disk_size_gb       = 2048
     enable_gcfs        = true
     enable_gvnic       = true
     initial_node_count = 0
@@ -65,7 +65,7 @@ locals {
     min_count          = 0
     max_count          = 20 # Higher max count for spot instances
     disk_type          = "pd-ssd"
-    disk_size_gb       = 1024
+    disk_size_gb       = 2048
     enable_gcfs        = true
     enable_gvnic       = true
     initial_node_count = 0

--- a/infra/modules/stacks/compute_cluster/gke.tf
+++ b/infra/modules/stacks/compute_cluster/gke.tf
@@ -14,7 +14,7 @@ locals {
     min_count          = 0
     max_count          = 10
     disk_type          = "pd-ssd"
-    disk_size_gb       = 2048
+    disk_size_gb       = 1500
     enable_gcfs        = true
     enable_gvnic       = true
     initial_node_count = 0
@@ -65,7 +65,7 @@ locals {
     min_count          = 0
     max_count          = 20 # Higher max count for spot instances
     disk_type          = "pd-ssd"
-    disk_size_gb       = 2048
+    disk_size_gb       = 1500
     enable_gcfs        = true
     enable_gvnic       = true
     initial_node_count = 0


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request introduces configuration changes to the infrastructure code, primarily increasing disk sizes for GKE node pools and enabling dry-run mode for cleanup policies in Artifact Registry repositories. These changes improve storage capacity and help validate cleanup policies before enforcing them.

Infrastructure improvements:

* Increased `disk_size_gb` from 1024 to 1500 for both the default and spot GKE node pools in `infra/modules/stacks/compute_cluster/gke.tf` to provide more storage per node. [[1]](diffhunk://#diff-c8752c8cb6721b71f98987ba4a697feccb364bde13760069bdae5d6b436cb40fL17-R17) [[2]](diffhunk://#diff-c8752c8cb6721b71f98987ba4a697feccb364bde13760069bdae5d6b436cb40fL68-R68)

Artifact Registry configuration:

* Enabled `cleanup_policy_dry_run` in `google_artifact_registry_repository` resources in `infra/modules/artifact_registry/main.tf` to allow testing cleanup policies without deleting artifacts.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- Nodes failing to run when requesting `1024GB` of storage.
- Docker images being deleted before 14 days


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [X] Made corresponding changes to the documentation

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
