### PR TITLE
Create generic ephemeral volumes pd csi that is tied to pod

### DIFF
--- a/docs/src/pipeline/debugging/debug_memory.md
+++ b/docs/src/pipeline/debugging/debug_memory.md
@@ -4,7 +4,31 @@
 
 Initially, we noticed the machine type was not being allocated. This due to the ephemeral storage requirements not being satisfied by any of the nodes.
 
-> We have bumped the storage of the boot disk to 1.5 TB.
+> To solve this, we have now added a volume to each node as a **Persistent Volume Claim (PVC)**. This size of this volume is calculated from the `ephemeral_storage_limit`. 
+
+The volume code:
+
+```yaml
+podSpecPatch: |
+  volumes:
+      - name: scratch
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: {% raw %}"{{inputs.parameters.ephemeral_storage_limit}}Gi"
+    {% endraw %}
+```
+
+And to mount this volume we do:
+
+```yaml
+volumeMounts
+  - name: scratch
+    mountPath: /scratch
+```
 
 ## Bumping memory spec
 

--- a/docs/src/pipeline/debugging/debug_memory.md
+++ b/docs/src/pipeline/debugging/debug_memory.md
@@ -30,6 +30,16 @@ volumeMounts
     mountPath: /scratch
 ```
 
+To make sure that the volumes are deleted after a pod succeeds/fails/error, we have set the 
+
+```yaml
+spec:
+  podGC:
+    strategy: OnPodCompletion
+```
+
+This ensures that the cleanup happens automatically.
+
 ## Bumping memory spec
 
 Next, we noticed the Neo4J container going OOM. It turned out this was due to the hardcoded values in the Neo4J container, essentially capping it's resources.

--- a/infra/modules/artifact_registry/main.tf
+++ b/infra/modules/artifact_registry/main.tf
@@ -6,7 +6,7 @@ resource "google_artifact_registry_repository" "this" {
   description            = var.description
   cleanup_policy_dry_run = true
   # Dynamic block to create the DELETE policy only if delete_older_than_days is greater than 0.
-  dynamic "cleanup_policies" {
+  dynamic "cleanup_policy_dry_run" {
     for_each = var.delete_older_than_days != null ? [1] : []
     content {
       id     = "delete-old-artifacts"
@@ -19,7 +19,7 @@ resource "google_artifact_registry_repository" "this" {
   }
 
   # Policy to delete sample-run images after 1 day (configurable)
-  dynamic "cleanup_policies" {
+  dynamic "cleanup_policy_dry_run" {
     for_each = length(var.sample_run_tag_prefixes) > 0 ? [1] : []
     content {
       id     = "delete-sample-run-images"

--- a/infra/modules/artifact_registry/main.tf
+++ b/infra/modules/artifact_registry/main.tf
@@ -6,7 +6,7 @@ resource "google_artifact_registry_repository" "this" {
   description            = var.description
   cleanup_policy_dry_run = true
   # Dynamic block to create the DELETE policy only if delete_older_than_days is greater than 0.
-  dynamic "cleanup_policy_dry_run" {
+  dynamic "cleanup_policies" {
     for_each = var.delete_older_than_days != null ? [1] : []
     content {
       id     = "delete-old-artifacts"
@@ -19,7 +19,7 @@ resource "google_artifact_registry_repository" "this" {
   }
 
   # Policy to delete sample-run images after 1 day (configurable)
-  dynamic "cleanup_policy_dry_run" {
+  dynamic "cleanup_policies" {
     for_each = length(var.sample_run_tag_prefixes) > 0 ? [1] : []
     content {
       id     = "delete-sample-run-images"

--- a/infra/modules/stacks/compute_cluster/gke.tf
+++ b/infra/modules/stacks/compute_cluster/gke.tf
@@ -14,7 +14,7 @@ locals {
     min_count          = 0
     max_count          = 10
     disk_type          = "pd-ssd"
-    disk_size_gb       = 1500
+    disk_size_gb       = 200
     enable_gcfs        = true
     enable_gvnic       = true
     initial_node_count = 0
@@ -65,7 +65,7 @@ locals {
     min_count          = 0
     max_count          = 20 # Higher max count for spot instances
     disk_type          = "pd-ssd"
-    disk_size_gb       = 1500
+    disk_size_gb       = 200
     enable_gcfs        = true
     enable_gvnic       = true
     initial_node_count = 0

--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -5,6 +5,8 @@ metadata:
   namespace: {{namespace}}
   name: {{run_name}}
 spec:
+  podGC:
+    strategy: OnPodCompletion
   workflowMetadata:
     labels:
       run: {% raw %}'{{ workflow.parameters.run_name }}'
@@ -120,6 +122,16 @@ spec:
       - name: ephemeral_storage_request
       - name: ephemeral_storage_limit
     podSpecPatch: |
+      volumes:
+          - name: scratch
+            ephemeral:
+              volumeClaimTemplate:
+                spec:
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: {% raw %}"{{inputs.parameters.ephemeral_storage_limit}}Gi"
+      {% endraw %}
       terminationGracePeriodSeconds: 30
       tolerations:
         - key: "node-memory-size"
@@ -156,6 +168,9 @@ spec:
               {% endraw %}
               ephemeral-storage: {% raw %} "{{inputs.parameters.ephemeral_storage_limit}}Gi"
               {% endraw %}
+            volumeMounts:
+              - name: scratch
+                mountPath: /scratch
     container: &_kedro_container
       imagePullPolicy: Always
       image: {% raw %} "{{workflow.parameters.image}}"
@@ -236,6 +251,16 @@ spec:
   - <<: *_kedro_template
     name: neo4j
     podSpecPatch: |
+      volumes:
+          - name: scratch
+            ephemeral:
+              volumeClaimTemplate:
+                spec:
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: {% raw %}"{{inputs.parameters.ephemeral_storage_limit}}Gi"
+        {% endraw %}
       terminationGracePeriodSeconds: 30
       tolerations:
         - key: "node-memory-size"
@@ -276,6 +301,9 @@ spec:
             # NOTE: We're passing in a regular bolt connection as ephemeral Neo4J has no SSL
             - name: NEO4J_HOST
               value: "bolt://127.0.0.1:7687"
+            volumeMounts
+              - name: scratch
+                mountPath: /scratch
         - name: neo4j
           resources:
             requests:
@@ -324,6 +352,9 @@ spec:
           - name: gds-key
             mountPath: /licences
             readOnly: true
+          - name: scratch
+            mountPath: /data
+
         env:
         - name: NEO4J_AUTH
           valueFrom:

--- a/pipelines/matrix/tests/test_argo.py
+++ b/pipelines/matrix/tests/test_argo.py
@@ -603,3 +603,169 @@ def test_retry_strategy_in_argo_template() -> None:
     assert "lastRetry.message matches '.*imminent node shutdown.*'" in expr
     assert "lastRetry.message matches '.*node is draining.*'" in expr
     assert "lastRetry.exitCode != 137" in expr
+
+
+def test_pod_gc_strategy_in_argo_template() -> None:
+    """Ensure the Argo workflow spec contains the expected podGC configuration."""
+    argo_default_resources = ArgoResourceConfig(
+        num_gpus=KUBERNETES_DEFAULT_NUM_GPUS,
+        cpu_request=KUBERNETES_DEFAULT_REQUEST_CPU,
+        cpu_limit=KUBERNETES_DEFAULT_LIMIT_CPU,
+        memory_request=KUBERNETES_DEFAULT_REQUEST_RAM,
+        memory_limit=KUBERNETES_DEFAULT_LIMIT_RAM,
+    )
+    argo_config, _ = get_argo_config(argo_default_resources)
+    spec = argo_config["spec"]
+
+    # Verify podGC configuration exists
+    assert "podGC" in spec
+    assert spec["podGC"]["strategy"] == "OnPodCompletion"
+
+
+def test_ephemeral_storage_in_pod_spec_patch() -> None:
+    """Ensure the kedro template contains ephemeral storage configuration in podSpecPatch."""
+    argo_default_resources = ArgoResourceConfig(
+        num_gpus=KUBERNETES_DEFAULT_NUM_GPUS,
+        cpu_request=KUBERNETES_DEFAULT_REQUEST_CPU,
+        cpu_limit=KUBERNETES_DEFAULT_LIMIT_CPU,
+        memory_request=KUBERNETES_DEFAULT_REQUEST_RAM,
+        memory_limit=KUBERNETES_DEFAULT_LIMIT_RAM,
+        ephemeral_storage_limit=256,  # Test with custom ephemeral storage
+        ephemeral_storage_request=64,
+    )
+    argo_config, _ = get_argo_config(argo_default_resources)
+    spec = argo_config["spec"]
+
+    kedro_template = next(t for t in spec["templates"] if t["name"] == "kedro")
+
+    # Verify podSpecPatch exists
+    assert "podSpecPatch" in kedro_template
+    pod_spec_patch = kedro_template["podSpecPatch"]
+
+    # Verify ephemeral volume configuration is present in podSpecPatch
+    assert "volumes:" in pod_spec_patch
+    assert "name: scratch" in pod_spec_patch
+    assert "ephemeral:" in pod_spec_patch
+    assert "volumeClaimTemplate:" in pod_spec_patch
+    assert 'accessModes: ["ReadWriteOnce"]' in pod_spec_patch
+    assert '"{{inputs.parameters.ephemeral_storage_limit}}Gi"' in pod_spec_patch
+
+    # Verify volume mounts are configured
+    assert "volumeMounts:" in pod_spec_patch
+    assert "name: scratch" in pod_spec_patch
+    assert "mountPath: /scratch" in pod_spec_patch
+
+
+def test_ephemeral_storage_parameters_in_template_tasks() -> None:
+    """Ensure template tasks include ephemeral storage parameters."""
+    argo_default_resources = ArgoResourceConfig(
+        num_gpus=KUBERNETES_DEFAULT_NUM_GPUS,
+        cpu_request=KUBERNETES_DEFAULT_REQUEST_CPU,
+        cpu_limit=KUBERNETES_DEFAULT_LIMIT_CPU,
+        memory_request=KUBERNETES_DEFAULT_REQUEST_RAM,
+        memory_limit=KUBERNETES_DEFAULT_LIMIT_RAM,
+        ephemeral_storage_limit=128,
+        ephemeral_storage_request=32,
+    )
+    argo_config, _ = get_argo_config(argo_default_resources)
+    spec = argo_config["spec"]
+
+    # Verify pipeline template exists
+    pipeline_template = next(t for t in spec["templates"] if t["name"] == "pipeline")
+    assert "dag" in pipeline_template
+
+    # Check that tasks have ephemeral storage parameters
+    if pipeline_template["dag"]["tasks"]:
+        task = pipeline_template["dag"]["tasks"][0]  # Check first task
+        parameters = {p["name"]: p["value"] for p in task["arguments"]["parameters"]}
+
+        # Verify ephemeral storage parameters are present
+        assert "ephemeral_storage_request" in parameters
+        assert "ephemeral_storage_limit" in parameters
+        assert parameters["ephemeral_storage_request"] == 0  # Default request is 0
+        assert parameters["ephemeral_storage_limit"] == argo_default_resources.ephemeral_storage_limit
+
+
+def test_kedro_template_input_parameters_include_ephemeral_storage() -> None:
+    """Ensure the kedro template declares ephemeral storage as input parameters."""
+    argo_default_resources = ArgoResourceConfig(
+        num_gpus=KUBERNETES_DEFAULT_NUM_GPUS,
+        cpu_request=KUBERNETES_DEFAULT_REQUEST_CPU,
+        cpu_limit=KUBERNETES_DEFAULT_LIMIT_CPU,
+        memory_request=KUBERNETES_DEFAULT_REQUEST_RAM,
+        memory_limit=KUBERNETES_DEFAULT_LIMIT_RAM,
+    )
+    argo_config, _ = get_argo_config(argo_default_resources)
+    spec = argo_config["spec"]
+
+    kedro_template = next(t for t in spec["templates"] if t["name"] == "kedro")
+
+    # Verify input parameters include ephemeral storage
+    assert "inputs" in kedro_template
+    assert "parameters" in kedro_template["inputs"]
+
+    parameter_names = [p["name"] for p in kedro_template["inputs"]["parameters"]]
+    assert "ephemeral_storage_request" in parameter_names
+    assert "ephemeral_storage_limit" in parameter_names
+
+
+def test_neo4j_template_ephemeral_storage_configuration() -> None:
+    """Ensure the neo4j template includes ephemeral storage configuration."""
+    argo_default_resources = ArgoResourceConfig(
+        num_gpus=KUBERNETES_DEFAULT_NUM_GPUS,
+        cpu_request=KUBERNETES_DEFAULT_REQUEST_CPU,
+        cpu_limit=KUBERNETES_DEFAULT_LIMIT_CPU,
+        memory_request=KUBERNETES_DEFAULT_REQUEST_RAM,
+        memory_limit=KUBERNETES_DEFAULT_LIMIT_RAM,
+        ephemeral_storage_limit=200,
+        ephemeral_storage_request=50,
+    )
+    argo_config, _ = get_argo_config(argo_default_resources)
+    spec = argo_config["spec"]
+
+    neo4j_template = next(t for t in spec["templates"] if t["name"] == "neo4j")
+
+    # Verify neo4j template has podSpecPatch with ephemeral storage
+    assert "podSpecPatch" in neo4j_template
+    pod_spec_patch = neo4j_template["podSpecPatch"]
+
+    # Verify ephemeral volume configuration
+    assert "volumes:" in pod_spec_patch
+    assert "name: scratch" in pod_spec_patch
+    assert "ephemeral:" in pod_spec_patch
+    assert "volumeClaimTemplate:" in pod_spec_patch
+    assert '"{{inputs.parameters.ephemeral_storage_limit}}Gi"' in pod_spec_patch
+
+    # Verify volume mounts for Neo4j sidecar
+    assert "volumeMounts" in pod_spec_patch
+    assert "mountPath: /scratch" in pod_spec_patch
+
+
+def test_resource_limits_with_ephemeral_storage_in_containers() -> None:
+    """Ensure container resources include ephemeral storage limits and requests."""
+    argo_default_resources = ArgoResourceConfig(
+        num_gpus=1,
+        cpu_request=4,
+        cpu_limit=8,
+        memory_request=32,
+        memory_limit=64,
+        ephemeral_storage_limit=150,
+        ephemeral_storage_request=75,
+    )
+    argo_config, _ = get_argo_config(argo_default_resources)
+    spec = argo_config["spec"]
+
+    kedro_template = next(t for t in spec["templates"] if t["name"] == "kedro")
+    pod_spec_patch = kedro_template["podSpecPatch"]
+
+    # Verify ephemeral storage is included in container resources
+    assert "ephemeral-storage:" in pod_spec_patch
+    assert '"{{inputs.parameters.ephemeral_storage_request}}Gi"' in pod_spec_patch
+    assert '"{{inputs.parameters.ephemeral_storage_limit}}Gi"' in pod_spec_patch
+
+    # Check that both requests and limits sections have ephemeral storage
+    requests_section = pod_spec_patch[pod_spec_patch.find("requests:") :]
+    limits_section = pod_spec_patch[pod_spec_patch.find("limits:") :]
+
+    assert "ephemeral-storage:" in requests_section
+    assert "ephemeral-storage:" in limits_section


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request introduces changes to both the GKE cluster configuration and the Argo workflow templates to optimize resource usage and improve ephemeral storage handling for workflows. The changes primarily reduce disk sizes for GKE nodes and enhance the way ephemeral storage is provisioned and mounted in workflow pods.

Instead of creating static one size disk for every pod (as only 1 pod runs on a VM), this PR will make sure that only the requested limit of ephemeral storage is assinged to each pod through a Persistent Volume Claim (PVC), and it is deleted as soon as the pod succeed/failed/Error. This will give us more control over the lifecycle of the disk.

# Test Arg Workflow

## Workload currently tested on (Ignore failure due to non-existent files)
https://argo.platform.prod.everycure.org/workflows/argo-workflows/nelson-sample-run-8484f39d?uid=0c9563f7-05c9-45d1-8237-3a0108ebf1f4

# Screenshots

<img width="2261" height="141" alt="Screenshot 2025-08-21 at 13 47 23" src="https://github.com/user-attachments/assets/e8b7dbe8-8cae-497c-93ba-33fb9c601272" />
<img width="1937" height="116" alt="Screenshot 2025-08-21 at 13 40 28" src="https://github.com/user-attachments/assets/8ab95d6c-f1ca-4340-934a-30dee2c109b6" />
<img width="3198" height="645" alt="Screenshot 2025-08-21 at 13 48 37" src="https://github.com/user-attachments/assets/47da95c6-f7db-4a4c-84bf-01b5fc2d58ec" />


**GKE Cluster Configuration:**

* Reduced the `disk_size_gb` for both standard and spot node pools from 1500GB to 200GB in `infra/modules/stacks/compute_cluster/gke.tf` to optimize resource allocation and potentially lower costs. [[1]](diffhunk://#diff-c8752c8cb6721b71f98987ba4a697feccb364bde13760069bdae5d6b436cb40fL17-R17) [[2]](diffhunk://#diff-c8752c8cb6721b71f98987ba4a697feccb364bde13760069bdae5d6b436cb40fL68-R68)

**Argo Workflow Template Improvements:**

* Added `podGC` with `OnPodCompletion` strategy to ensure pods are cleaned up after workflow execution even if it failed or has an error, improving resource management.

* Provisioned an ephemeral `scratch` volume using a `volumeClaimTemplate` in workflow pods, dynamically requesting storage based on the `ephemeral_storage_limit` parameter. [[1]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R125-R134) [[2]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R254-R263)
* Mounted the `scratch` volume at `/scratch` in main containers and at `/data` for Neo4j, making ephemeral storage accessible for workflow steps. [[1]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R171-R173) [[2]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R304-R306) [[3]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R355-R357)

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [X] Made corresponding changes to the documentation
- [X] Added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [X] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [X] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

## Merge Notification

Please take a pull from main branch