### PR TITLE
Run sampling pipeline only on weekdays

### DIFF
--- a/.github/workflows/scheduled-sampling-pipeline.yml
+++ b/.github/workflows/scheduled-sampling-pipeline.yml
@@ -2,7 +2,7 @@ name: Scheduled Sampling Pipeline
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # every day at midnight GMT
+    - cron: '0 0 * * 1-5'  # every weekday (Monday to Friday) at midnight GMT
   workflow_dispatch: 
     inputs:
       release_version:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

The sampling pipeline runs to determine if latest changes to main do break it. We do not need to run it on weekends as we don't add changes there. I am though aware that submitting this PR on a Sunday contradicts my last sentence.

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
