### PR TITLE
Improve error logs in core node normalization

### DIFF
--- a/pipelines/matrix/src/matrix/pipelines/integration/nodes.py
+++ b/pipelines/matrix/src/matrix/pipelines/integration/nodes.py
@@ -324,7 +324,9 @@ def normalize_core_nodes(
             f"Multiple core_ids found for the same normalized_id. "
             f"Please fix source data."
         )
-        conflicts.show(truncate=False)
+        nodes_normalized.join(conflicts, on="id", how="inner").select("id", "core_id", "distinct_core_ids").orderBy(
+            "distinct_core_ids", ascending=False
+        ).show(truncate=False)
         raise Exception("Normalized ID conflicts detected; please investigate")
     else:
         logger.info("No normalized ID conflicts found.")

--- a/pipelines/matrix/src/matrix/pipelines/integration/nodes.py
+++ b/pipelines/matrix/src/matrix/pipelines/integration/nodes.py
@@ -325,7 +325,7 @@ def normalize_core_nodes(
             f"Please fix source data."
         )
         nodes_normalized.join(conflicts, on="id", how="inner").select("id", "core_id", "distinct_core_ids").orderBy(
-            "distinct_core_ids", ascending=False
+            "distinct_core_ids", "id", ascending=False
         ).show(truncate=False)
         raise Exception("Normalized ID conflicts detected; please investigate")
     else:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

We raise an error when two core nodes (for example: two drugs or two diseases) normalize to the same node. The current error does not show the erroneous nodes' id in detail. We're improving it in this PR.

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
