### PR TITLE
Fix the broken BQ SQL queries on the dashboard

### DIFF
--- a/services/kg_dashboard/Makefile
+++ b/services/kg_dashboard/Makefile
@@ -7,7 +7,7 @@ EC_DATA_DOMAIN ?= data.dev.everycure.org
 EVIDENCE_BASE_PATH = gs://$(EC_DATA_DOMAIN)/versions
 
 # Change release version of the KG used in the dashboard
-RELEASE_VERSION ?= v0.7.0
+RELEASE_VERSION ?= v0.9.5
 export EVIDENCE_VAR__release_version := $(RELEASE_VERSION)
 export EVIDENCE_VAR__bq_release_version := $(subst .,_,$(RELEASE_VERSION))
 export VITE_release_version := $(RELEASE_VERSION)

--- a/services/kg_dashboard/pages/EC Core Entities/disease-list.md
+++ b/services/kg_dashboard/pages/EC Core Entities/disease-list.md
@@ -134,53 +134,27 @@ by prefix and category.
     />
     <Tabs fullWidth=true>
         <Tab label="Success">
-            <Tabs>
-              <Tab label="Prefixes">
-                <DataTable
-                          data={disease_list_success
-                            .filter(d => d.normalization_success === true && d.dimension === 'prefix')
-                            .map(({ name, count }) => ({ name, count }))}
-                          columns={['name', 'count']}
-                          pagination
-                          pageSize={10}
-                        />
-              </Tab>
-              <Tab label="Categories">
-                <DataTable
-                          data={disease_list_success
-                            .filter(d => d.normalization_success === true && d.dimension === 'category')
-                            .map(({ name, count }) => ({ name, count }))}
-                          columns={['name', 'count']}
-                          pagination
-                          pageSize={10}
-                        />
-              </Tab>
-            </Tabs>
+            <DataTable
+                data={disease_list_success
+                    .filter(d => d.normalization_success === true && d.dimension === 'prefix')
+                    .map(({ name, count }) => ({ name, count }))}
+                columns={['name', 'count']}
+                pagination
+                pageSize={10}
+            />
         </Tab>
+        {#if disease_list_success.filter(d => d.normalization_success === false && d.dimension === 'prefix').length > 0}
         <Tab label="Failure">
-            <Tabs>
-              <Tab label="Prefixes">
-                <DataTable
-                          data={disease_list_success
-                            .filter(d => d.normalization_success === false && d.dimension === 'prefix')
-                            .map(({ name, count }) => ({ name, count }))}
-                          columns={['name', 'count']}
-                          pagination
-                          pageSize={10}
-                        />
-              </Tab>
-              <Tab label="Categories">
-                <DataTable
-                          data={disease_list_success
-                            .filter(d => d.normalization_success === false && d.dimension === 'category')
-                            .map(({ name, count }) => ({ name, count }))}
-                          columns={['name', 'count']}
-                          pagination
-                          pageSize={10}
-                        />
-              </Tab>
-            </Tabs>
+            <DataTable
+                data={disease_list_success
+                    .filter(d => d.normalization_success === false && d.dimension === 'prefix')
+                    .map(({ name, count }) => ({ name, count }))}
+                columns={['name', 'count']}
+                pagination
+                pageSize={10}
+            />
         </Tab>
+        {/if}
     </Tabs>
 </Grid>
 

--- a/services/kg_dashboard/pages/EC Core Entities/drug-list.md
+++ b/services/kg_dashboard/pages/EC Core Entities/drug-list.md
@@ -100,6 +100,7 @@ by prefix and category.
 
 <Grid col=2>
     <ECharts
+        style={{ height: '500px' }},
         config={{
             tooltip: {
                 formatter: function(params) {
@@ -110,6 +111,7 @@ by prefix and category.
             series: [{
                 type: 'pie', 
                 radius: ['30%', '50%'],
+                center: ['50%', '50%'],
                 data: drug_list_normalization.map(d => ({
                     ...d,
                     itemStyle: {
@@ -121,53 +123,27 @@ by prefix and category.
     />
     <Tabs fullWidth=true>
         <Tab label="Success">
-            <Tabs>
-              <Tab label="Prefixes">
-                <DataTable
-                          data={drug_list_success
-                            .filter(d => d.normalization_success === true && d.dimension === 'prefix')
-                            .map(({ name, count }) => ({ name, count }))}
-                          columns={['name', 'count']}
-                          pagination
-                          pageSize={10}
-                        />
-              </Tab>
-              <Tab label="Categories">
-                <DataTable
-                          data={drug_list_success
-                            .filter(d => d.normalization_success === true && d.dimension === 'category')
-                            .map(({ name, count }) => ({ name, count }))}
-                          columns={['name', 'count']}
-                          pagination
-                          pageSize={10}
-                        />
-              </Tab>
-            </Tabs>
+            <DataTable
+                data={drug_list_success
+                    .filter(d => d.normalization_success === true && d.dimension === 'prefix')
+                    .map(({ name, count }) => ({ name, count }))}
+                columns={['name', 'count']}
+                pagination
+                pageSize={10}
+            />
         </Tab>
+        {#if drug_list_success.filter(d => d.normalization_success === false && d.dimension === 'prefix').length > 0}
         <Tab label="Failure">
-            <Tabs>
-              <Tab label="Prefixes">
-                <DataTable
-                          data={drug_list_success
-                            .filter(d => d.normalization_success === false && d.dimension === 'prefix')
-                            .map(({ name, count }) => ({ name, count }))}
-                          columns={['name', 'count']}
-                          pagination
-                          pageSize={10}
-                        />
-              </Tab>
-              <Tab label="Categories">
-                <DataTable
-                          data={drug_list_success
-                            .filter(d => d.normalization_success === false && d.dimension === 'category')
-                            .map(({ name, count }) => ({ name, count }))}
-                          columns={['name', 'count']}
-                          pagination
-                          pageSize={10}
-                        />
-              </Tab>
-            </Tabs>
+            <DataTable
+                data={drug_list_success
+                    .filter(d => d.normalization_success === false && d.dimension === 'prefix')
+                    .map(({ name, count }) => ({ name, count }))}
+                columns={['name', 'count']}
+                pagination
+                pageSize={10}
+            />
         </Tab>
+        {/if}
     </Tabs>
 </Grid>
 

--- a/services/kg_dashboard/sources/bq/disease_list_success.sql
+++ b/services/kg_dashboard/sources/bq/disease_list_success.sql
@@ -7,20 +7,6 @@ FROM `${project_id}.release_${bq_release_version}.disease_list_normalization_sum
 GROUP BY
   normalization_success,
   name
-
-UNION ALL
-
-SELECT
-  normalization_success,
-  'category' AS dimension,
-  category AS name,
-  COUNT(*) AS count
-FROM `${project_id}.release_${bq_release_version}.disease_list_normalization_summary`
-GROUP BY
-  normalization_success,
-  category
-
 ORDER BY
   normalization_success DESC,
-  dimension,
   count DESC;

--- a/services/kg_dashboard/sources/bq/drug_list_success.sql
+++ b/services/kg_dashboard/sources/bq/drug_list_success.sql
@@ -7,20 +7,6 @@ FROM `${project_id}.release_${bq_release_version}.drug_list_normalization_summar
 GROUP BY
   normalization_success,
   name
-
-UNION ALL
-
-SELECT
-  normalization_success,
-  'category' AS dimension,
-  category AS name,
-  COUNT(*) AS count
-FROM `${project_id}.release_${bq_release_version}.drug_list_normalization_summary`
-GROUP BY
-  normalization_success,
-  category
-
 ORDER BY
   normalization_success DESC,
-  dimension,
   count DESC;


### PR DESCRIPTION
# Description of the changes
Updated drug and disease list normalization visualizations to remove unused category dimension and conditionally show failure tabs only when normalization failures exist.

## Fixes / Resolves the following issues:
- Updated RELEASE_VERSION from v0.9.4 to v0.9.5 in Makefile to use correct BigQuery dataset 
- Removed redundant category breakdowns from normalization queries (diseases are always diseases, drugs are always drugs)
- Fixed empty "Failure" tabs showing error messages when all entities normalize successfully
- Simplified visualization to focus on actionable prefix-based breakdowns
- Conditionally render failure tabs only when normalization_success = false records exist


This resolves 
https://linear.app/everycure/issue/XDATA-110/update-evidencedev-queries-to-align-with-new-category-columns-in-drug

And will unblock: 
https://github.com/everycure-org/matrix/pull/1790 

Which cannot pass CI because v0.9.4 is an incomplete build. 

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
