### PR TITLE
fix: use command in apply function to use 'create' instead of 'apply'…

### DIFF
--- a/pipelines/matrix/src/matrix/utils/kubernetes.py
+++ b/pipelines/matrix/src/matrix/utils/kubernetes.py
@@ -110,12 +110,12 @@ def create_namespace(namespace: str, verbose: bool):
 
 
 def apply(namespace, file_path: Path, verbose: bool):
-    """Apply file to kubernetes namespace
+    """Create file to kubernetes namespace
 
-    `kubectl apply -f <file_path> -n <namespace>` will make the template available as a resource (but will not create any other resources, and will not trigger the workshop).
+    `kubectl create -f <file_path> -n <namespace>` will make the template available as a resource (but will not create any other resources, and will not trigger the workshop).
     """
 
-    cmd = f"kubectl apply -f {file_path} -n {namespace}"
+    cmd = f"kubectl create -f {file_path} -n {namespace}"
     run_subprocess(
         cmd,
         check=True,


### PR DESCRIPTION
… to avoid size error

# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request makes a small but important change to the Kubernetes utility function responsible for applying resource files. The function now uses `kubectl create` instead of `kubectl apply` when adding resources to a namespace, ensuring that resources are only created if they do not already exist.

- Changed the `apply` function in `kubernetes.py` to use `kubectl create` instead of `kubectl apply`, updating both the command and the docstring to reflect this behavior.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- annotation size error


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
