### PR TITLE
Hotfix/remove last ephemeral storage limit from pod directly

### DIFF
--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -412,8 +412,6 @@ spec:
             value: {{ task.resources.cpu_request }}
           - name: cpu_limit
             value: {{ task.resources.cpu_limit }}
-          - name: ephemeral_storage_request
-            value: {{ task.resources.ephemeral_storage_request }}
 
       {% endfor %}
 

--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -414,8 +414,6 @@ spec:
             value: {{ task.resources.cpu_limit }}
           - name: ephemeral_storage_request
             value: {{ task.resources.ephemeral_storage_request }}
-          - name: ephemeral_storage_limit
-            value: {{ task.resources.ephemeral_storage_limit }}
 
       {% endfor %}
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request makes a small change to the Argo workflow specification template by removing the ephemeral storage resource requests and limits from the task configuration.

* Removed `ephemeral_storage_request` and `ephemeral_storage_limit` resource specifications from the task environment variables in `argo_wf_spec.tmpl`.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
