### PR TITLE
Update ground truth table names in KG dashboard

### DIFF
--- a/services/kg_dashboard/Makefile
+++ b/services/kg_dashboard/Makefile
@@ -7,7 +7,7 @@ EC_DATA_DOMAIN ?= data.dev.everycure.org
 EVIDENCE_BASE_PATH = gs://$(EC_DATA_DOMAIN)/versions
 
 # Change release version of the KG used in the dashboard
-RELEASE_VERSION ?= v0.9.5
+RELEASE_VERSION ?= v0.9.9
 export EVIDENCE_VAR__release_version := $(RELEASE_VERSION)
 export EVIDENCE_VAR__bq_release_version := $(subst .,_,$(RELEASE_VERSION))
 export VITE_release_version := $(RELEASE_VERSION)

--- a/services/kg_dashboard/sources/bq/edge_failed_normalization_examples.sql
+++ b/services/kg_dashboard/sources/bq/edge_failed_normalization_examples.sql
@@ -56,9 +56,9 @@ WITH ranked_data AS (
             name,
             SPLIT(subject, ':')[OFFSET(0)] AS prefix,
             category,
-            'ground_truth' AS normalization_set,
+            'kgml_xdtd_ground_truth' AS normalization_set,
         FROM 
-            `${project_id}.release_${bq_release_version}.ground_truth_edges_normalized`        
+            `${project_id}.release_${bq_release_version}.kgml_xdtd_ground_truth_edges_normalized`        
             JOIN `${project_id}.release_${bq_release_version}.rtx_kg2_nodes_normalized` ON subject = id
         WHERE subject_normalization_success = false
         UNION DISTINCT
@@ -67,9 +67,31 @@ WITH ranked_data AS (
             name,
             SPLIT(object, ':')[OFFSET(0)] AS prefix, 
             category,
-            'ground_truth' AS normalization_set,
+            'kgml_xdtd_ground_truth' AS normalization_set,
         FROM 
-            `${project_id}.release_${bq_release_version}.ground_truth_edges_normalized`        
+            `${project_id}.release_${bq_release_version}.kgml_xdtd_ground_truth_edges_normalized`        
+            JOIN `${project_id}.release_${bq_release_version}.rtx_kg2_nodes_normalized` ON object = id
+        WHERE object_normalization_success = false
+        UNION DISTINCT
+        SELECT 
+            subject AS id,
+            name,
+            SPLIT(subject, ':')[OFFSET(0)] AS prefix,
+            category,
+            'ec_ground_truth' AS normalization_set,
+        FROM 
+            `${project_id}.release_${bq_release_version}.ec_ground_truth_edges_normalized`        
+            JOIN `${project_id}.release_${bq_release_version}.rtx_kg2_nodes_normalized` ON subject = id
+        WHERE subject_normalization_success = false
+        UNION DISTINCT
+        SELECT 
+            object AS id,
+            name,
+            SPLIT(object, ':')[OFFSET(0)] AS prefix, 
+            category,
+            'ec_ground_truth' AS normalization_set,
+        FROM 
+            `${project_id}.release_${bq_release_version}.ec_ground_truth_edges_normalized`        
             JOIN `${project_id}.release_${bq_release_version}.rtx_kg2_nodes_normalized` ON object = id
         WHERE object_normalization_success = false
         UNION DISTINCT

--- a/services/kg_dashboard/sources/bq/normalization.sql
+++ b/services/kg_dashboard/sources/bq/normalization.sql
@@ -80,7 +80,7 @@ FROM (
     subject_normalization_success AS normalization_success,
     CASE WHEN original_subject = subject THEN true ELSE false END AS no_normalization_change 
   FROM 
-    `${project_id}.release_${bq_release_version}.ground_truth_edges_normalized`
+    `${project_id}.release_${bq_release_version}.kgml_xdtd_ground_truth_edges_normalized`
   UNION DISTINCT
   SELECT 
     object AS id,
@@ -89,7 +89,25 @@ FROM (
     object_normalization_success AS normalization_success,
     CASE WHEN original_object = object THEN true ELSE false END AS no_normalization_change 
   FROM 
-    `${project_id}.release_${bq_release_version}.ground_truth_edges_normalized`
+    `${project_id}.release_${bq_release_version}.kgml_xdtd_ground_truth_edges_normalized`
+  UNION DISTINCT
+  SELECT 
+    subject AS id,
+    original_subject AS original_id,
+    '' as category,
+    subject_normalization_success AS normalization_success,
+    CASE WHEN original_subject = subject THEN true ELSE false END AS no_normalization_change 
+  FROM 
+    `${project_id}.release_${bq_release_version}.ec_ground_truth_edges_normalized`
+  UNION DISTINCT
+  SELECT 
+    object AS id,
+    original_object AS original_id,
+    '' as category,
+    object_normalization_success AS normalization_success,
+    CASE WHEN original_object = object THEN true ELSE false END AS no_normalization_change 
+  FROM 
+    `${project_id}.release_${bq_release_version}.ec_ground_truth_edges_normalized`
 )
 GROUP BY ALL
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Previous changes have split the ground truth in two different sources, the KG dashboard source names had not been updated. This PR updates them?


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
