### PR TITLE
Only write final filtered tables to BQ

### DIFF
--- a/pipelines/matrix/conf/cloud/filtering/catalog.yml
+++ b/pipelines/matrix/conf/cloud/filtering/catalog.yml
@@ -28,18 +28,15 @@ _spark_parquet_ds: &_spark_parquet
 filtering.prm.removed_nodes_initial:
   <<: *_spark_parquet
   filepath: ${globals:paths.filtering}/prm/removed/nodes_initial
-  table: nodes_removed
 
 # Removed edges due to filtering or missing nodes
 filtering.prm.removed_edges:
   <<: *_spark_parquet
   filepath: ${globals:paths.filtering}/prm/removed/edges
-  table: edges_removed
 
 filtering.prm.removed_nodes_final:
   <<: *_spark_parquet
   filepath: ${globals:paths.filtering}/prm/removed/nodes_final
-  table: nodes_removed_final
 
 # Filtered PRM nodes/edges written to BigQuery
 filtering.prm.filtered_nodes:

--- a/pipelines/matrix/conf/cloud/filtering/catalog.yml
+++ b/pipelines/matrix/conf/cloud/filtering/catalog.yml
@@ -8,6 +8,15 @@ _bigquery_ds: &_bigquery_ds
     labels:
       git_sha: ${globals:git_sha}
 
+
+_spark_parquet_ds: &_spark_parquet
+  type: matrix.datasets.gcp.LazySparkDataset
+  file_format: parquet
+  load_args:
+    header: True
+  save_args:
+    mode: overwrite
+
 # -------------------------------------------------------------------------
 # Datasets
 # -------------------------------------------------------------------------
@@ -17,15 +26,20 @@ _bigquery_ds: &_bigquery_ds
 
 # Removed nodes after initial filter step
 filtering.prm.removed_nodes_initial:
-  <<: *_bigquery_ds
+  <<: *_spark_parquet
   filepath: ${globals:paths.filtering}/prm/removed/nodes_initial
   table: nodes_removed
 
 # Removed edges due to filtering or missing nodes
 filtering.prm.removed_edges:
-  <<: *_bigquery_ds
+  <<: *_spark_parquet
   filepath: ${globals:paths.filtering}/prm/removed/edges
   table: edges_removed
+
+filtering.prm.removed_nodes_final:
+  <<: *_spark_parquet
+  filepath: ${globals:paths.filtering}/prm/removed/nodes_final
+  table: nodes_removed_final
 
 # Filtered PRM nodes/edges written to BigQuery
 filtering.prm.filtered_nodes:
@@ -38,7 +52,3 @@ filtering.prm.filtered_edges:
   filepath: ${globals:paths.filtering}/prm/filtered/edges
   table: edges_filtered
 
-filtering.prm.removed_nodes_final:
-  <<: *_bigquery_ds
-  filepath: ${globals:paths.filtering}/prm/removed/nodes_final
-  table: nodes_removed_final


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


<img width="481" height="219" alt="Screenshot 2025-09-01 at 13 36 40" src="https://github.com/user-attachments/assets/d3f63f5f-e72b-49e1-a811-b057c0e45d53" />

We write too many filtering tables to BQ - it is confusing

I think we only need the filtered nodes and edges here


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
