### PR TITLE
Nelson/aip 530 fix issue caused by recent changes in the code

### DIFF
--- a/.github/workflows/scheduled-sampling-pipeline.yml
+++ b/.github/workflows/scheduled-sampling-pipeline.yml
@@ -116,7 +116,7 @@ jobs:
           
           DATE=$(date +%Y%m%d)
           echo "Run the kedro sampling pipeline"
-          kedro experiment run \
+          uv run kedro experiment run \
             -e sample \
             -p test_sample \
             --experiment-name scheduled-sampled-run \

--- a/.github/workflows/scheduled-sampling-pipeline.yml
+++ b/.github/workflows/scheduled-sampling-pipeline.yml
@@ -62,7 +62,7 @@ jobs:
           df -h
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/submit-kedro-pipeline.yml
+++ b/.github/workflows/submit-kedro-pipeline.yml
@@ -138,7 +138,7 @@ jobs:
           else
             RELEASE_PIPELINE='kg_release_patch_and_matrix_run'
           fi
-          kedro experiment run \
+          uv run kedro experiment run \
             --username GH-Actions-bot \
             --namespace argo-workflows \
             --experiment-name scheduled-kg-release \

--- a/.github/workflows/submit-kedro-pipeline.yml
+++ b/.github/workflows/submit-kedro-pipeline.yml
@@ -52,7 +52,7 @@ jobs:
           df -h
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.11'
 
@@ -60,7 +60,7 @@ jobs:
         working-directory: pipelines/matrix
         run: |
           make install_argo
-          uv sync
+          make install
 
       - name: Authenticate with Google Cloud
         id: auth

--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -47,10 +47,6 @@ spec:
         value: "{{ mlflow_url }}"
       - name: include_private_datasets
         value: "{{ include_private_datasets }}"
-      - name: ephemeral_storage_request
-        value: "{{ ephemeral_storage_request }}"
-      - name: ephemeral_storage_limit
-        value: "{{ ephemeral_storage_limit }}"
   templates:
   - &_kedro_template
     metrics:
@@ -444,6 +440,8 @@ spec:
             value: {{ task.resources.cpu_limit }}
           - name: ephemeral_storage_request
             value: {{ task.resources.ephemeral_storage_request }}
+          - name: ephemeral_storage_limit
+            value: {{ task.resources.ephemeral_storage_limit }}
 
       {% endfor %}
 

--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -47,6 +47,10 @@ spec:
         value: "{{ mlflow_url }}"
       - name: include_private_datasets
         value: "{{ include_private_datasets }}"
+      - name: ephemeral_storage_request
+        value: "{{ ephemeral_storage_request }}"
+      - name: ephemeral_storage_limit
+        value: "{{ ephemeral_storage_limit }}"
   templates:
   - &_kedro_template
     metrics:

--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -440,8 +440,6 @@ spec:
             value: {{ task.resources.cpu_limit }}
           - name: ephemeral_storage_request
             value: {{ task.resources.ephemeral_storage_request }}
-          - name: ephemeral_storage_limit
-            value: {{ task.resources.ephemeral_storage_limit }}
 
       {% endfor %}
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

FWIW: `make install` uses `uv sync` which is the same.

This pull request updates the CI workflows to use `uv` image for Python environment management and adds a new test to ensure ephemeral storage parameters are correctly included in Argo pipeline task arguments. The main themes are improvements to workflow reliability and enhanced test coverage for resource configuration.

**CI Workflow Improvements:**

* Updated both `.github/workflows/scheduled-sampling-pipeline.yml` and `.github/workflows/submit-kedro-pipeline.yml` to use `astral-sh/setup-uv@v6` instead of `actions/setup-python@v5` for Python environment setup, and replaced direct `uv sync` with `make install` (which does `uv sync` under the hood) for dependency installation. [[1]](diffhunk://#diff-22556473b7390d103c65abcf33170dc5c2a759461afbf290b4c535504e8a56c0L65-R65) [[2]](diffhunk://#diff-abc3967202f4551381466c889d963c15aa5fe479e486f758c7d62d1a2fc26eabL55-R63)
* Changed pipeline execution commands in both workflows to use `uv run kedro experiment run` instead of calling `kedro` directly, ensuring execution within the managed environment. [[1]](diffhunk://#diff-22556473b7390d103c65abcf33170dc5c2a759461afbf290b4c535504e8a56c0L119-R119) [[2]](diffhunk://#diff-abc3967202f4551381466c889d963c15aa5fe479e486f758c7d62d1a2fc26eabL141-R141)

**Test Coverage Enhancements:**

* Added `test_pipeline_task_arguments_include_ephemeral_storage_parameters` to `pipelines/matrix/tests/test_argo.py`, verifying that both `ephemeral_storage_request` and `ephemeral_storage_limit` are present and correctly set in Argo pipeline task arguments.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- uv command not found


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [X] Added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [X] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [X] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
