### PR TITLE
Add benchmark release link

### DIFF
--- a/pipelines/matrix/conf/base/globals.yml
+++ b/pipelines/matrix/conf/base/globals.yml
@@ -25,6 +25,7 @@ gh_token: ${oc.env:GH_TOKEN, dummy}
 run_name: ${oc.env:RUN_NAME, default-run-name}
 versions:
   release: local-release
+  benchmark_release: v0.4.5
 
 data_sources:
   rtx_kg2:

--- a/services/kg_dashboard/Makefile
+++ b/services/kg_dashboard/Makefile
@@ -7,7 +7,10 @@ EC_DATA_DOMAIN ?= data.dev.everycure.org
 EVIDENCE_BASE_PATH = gs://$(EC_DATA_DOMAIN)/versions
 
 # Change release version of the KG used in the dashboard
+
 RELEASE_VERSION ?= v0.9.9
+
+
 export EVIDENCE_VAR__release_version := $(RELEASE_VERSION)
 export EVIDENCE_VAR__bq_release_version := $(subst .,_,$(RELEASE_VERSION))
 export VITE_release_version := $(RELEASE_VERSION)
@@ -20,10 +23,14 @@ export VITE_build_time := $(shell date -u '+%B %d, %Y at %H:%M:%S UTC')
 KEDRO_BASE_GLOBALS_PATH = "../../pipelines/matrix/conf/base/globals.yml"
 ROBOKOP_VERSION = $(shell grep -A1 "robokop:" $(KEDRO_BASE_GLOBALS_PATH) | grep "version:" | sed 's/.*version: //')
 RTX_KG2_VERSION = $(shell grep -A1 "rtx_kg2:" $(KEDRO_BASE_GLOBALS_PATH) | grep "version:" | sed 's/.*version: //' | sed 's/^&_rtx_kg_version //' | sed -E 's/\./_/g')
+BENCHMARK_VERSION = $(shell grep -A1 "benchmark_release:" $(KEDRO_BASE_GLOBALS_PATH) | grep "benchmark_release:" | sed 's/.*benchmark_release: //')
+
 export EVIDENCE_VAR__robokop_version := $(ROBOKOP_VERSION)
 export EVIDENCE_VAR__rtx_kg2_version := $(RTX_KG2_VERSION)
+export EVIDENCE_VAR__benchmark_version := $(BENCHMARK_VERSION)
 export VITE_robokop_version := $(ROBOKOP_VERSION)
 export VITE_rtx_kg2_version := $(RTX_KG2_VERSION)
+export VITE_benchmark_version := $(BENCHMARK_VERSION)
 
 MAX_CORE_ENTITIES_NORMALIZATION_ERRORS = 1000
 export EVIDENCE_VAR__max_core_entities_normalization_errors := $(MAX_CORE_ENTITIES_NORMALIZATION_ERRORS)
@@ -65,6 +72,7 @@ run-sources: populate-infores-source populate-valid-edge-types-source
 	npm run sources
 
 run-dev:
+	echo "BENCHMARK_VERSION=$(BENCHMARK_VERSION)"
 	npm run dev
 
 clean:

--- a/services/kg_dashboard/evidence.config.yaml
+++ b/services/kg_dashboard/evidence.config.yaml
@@ -1,6 +1,6 @@
 deployment:
   # The version below should be automatically updated by "update-basepath.cjs" script, that is triggered in the Makefile
-  basePath: /versions/v0.7.0/evidence
+  basePath: /versions/v0.9.9/evidence
 
 plugins: 
   

--- a/services/kg_dashboard/pages/index.md
+++ b/services/kg_dashboard/pages/index.md
@@ -2,28 +2,32 @@
 title: KG Dashboard
 ---
 
-<div class="mb-4">
-  <a href="https://docs.dev.everycure.org/releases/release_history/" class="inline-flex items-center text-blue-600 hover:text-blue-800 text-sm">
-    ← Release History
-  </a>
-</div>
-
 <script context="module">
-  import { getSourceColor } from './_lib/colors';
-  
-  // Function to get colors for pie chart data
-  export function getPieColors(data) {
-    return data.map(item => getSourceColor(item.name));
-  }
+    import { getSourceColor } from './_lib/colors';
+    
+    // Function to get colors for pie chart data
+    export function getPieColors(data) {
+        return data.map(item => getSourceColor(item.name));
+    }
+
+    const release_version = import.meta.env.VITE_release_version;
+    const build_time = import.meta.env.VITE_build_time;
+    const robokop_version = import.meta.env.VITE_robokop_version;
+    const rtx_kg2_version = import.meta.env.VITE_rtx_kg2_version;
+    const benchmark_version = import.meta.env.VITE_benchmark_version;
+
 </script>
 
-<script>
-  const release_version = import.meta.env.VITE_release_version;
-  const build_time = import.meta.env.VITE_build_time;
-  const robokop_version = import.meta.env.VITE_robokop_version;
-  const rtx_kg2_version = import.meta.env.VITE_rtx_kg2_version;
 
-</script>
+<div class="mb-4 flex flex-col gap-2">
+    <a href="../../../releases/release_history/" class="inline-flex items-center text-blue-600 hover:text-blue-800 text-sm">
+        ← Release History 
+    </a>
+    <a href={"../../" + benchmark_version + "/evidence/index.md"} class="inline-flex items-center text-blue-600 hover:text-blue-800 text-sm">
+        🔖 Benchmark Release ({benchmark_version})
+    </a>
+</div>
+# release_version: {release_version}
 
 This dashboard provides an overview of our integrated knowledge graph (KG), detailing its size, connectivity patterns, and provenance quality. 
 It also examines how nodes from our curated disease and drug lists link to other entities within the graph.


### PR DESCRIPTION
This PR defines the benchmark release in the base globals.yml as v0.4.5 (very open to suggestions on where it should go within globals.yml!) and adds relative link to the benchmark release dashboard page.

I realized that the release history page might not be appropriate to hardcode as data.dev.everycure.org, if it's also being deployed to prod with a different url, so I changed that to a relative link as well.

The final change was a little bit of refactoring to combine variable definitions and color functions into the same script tag, I thought there was some limitation on the number of script tags in these pages, but I'm realizing now that it's probably an unnecessary change. Maybe a little tidier?
