### PR TITLE
Allow docs data directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # Data
 data/
+!docs/**/data/
 neo4j_db/
 data.tar.gz
 


### PR DESCRIPTION
# Description of the changes 

Added an exception to .gitignore to include data directories under docs, while continuing to ignore the main data/ directory. This enables documentation-specific data to be tracked in version control.


## Fixes / Resolves the following issues:

I want to add a new documentation page into the `docs/src/pipeline/data/` directory. the rule `data/` in the `.gitignore` files precludes this.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))
