### PR TITLE
Add documentation page for the primary knowledge sources in the KG

### DIFF
--- a/docs/src/pipeline/data/knowledgegraph.md
+++ b/docs/src/pipeline/data/knowledgegraph.md
@@ -1,0 +1,7 @@
+# Knowledge Graph
+
+The MATRIX platform leverages and produces comprehensive knowledge graphs to study drug-disease relationships and enable drug repurposing predictions.
+
+## Related resources:
+
+- [Overview of the primary knowledge sources included in our merged knowledge graph](primary_knowledge_sources.md) 

--- a/docs/src/pipeline/data/primary_knowledge_sources.md
+++ b/docs/src/pipeline/data/primary_knowledge_sources.md
@@ -1,0 +1,2339 @@
+# KG Primary Knowledge Sources
+                                   
+This page is automatically generated with curated information about primary knowledge sources
+leveraged in the MATRIX Knowledge Graph, mainly regarding licensing information and 
+potential relevancy assessments for drug repurposing.
+
+This internally curated information is augmented with information from three external resources:
+
+1. [Information Resource Registry](https://biolink.github.io/information-resource-registry/)
+2. [reusabledata.org](https://reusabledata.org/)
+3. [KG Registry](https://kghub.org/kg-registry/)
+
+## Overview
+
+**Overview table**
+
+
+
+| Resource | License |
+| -------- | ------- |
+| Semantic Medline Database | [UMLS Metathesaurus](https://academic.oup.com/bioinformatics/article/28/23/3158/195282) |
+| Search Tool for the Retrieval of Interacting Genes/Proteins | [CC BY 4.0](https://string-db.org/cgi/access?footer_active_subpage=licensing) |
+| PathWhiz | [David Wishart, Departments of Computing Science & Biological Sciences, University of Alberta.](https://smpdb.ca/pathwhiz) |
+| DrugBank | [CC BY-NC 4.0 (Complete Database including structures, external links, protein identifiers, target sequences, drug sequences), CC0 1.0 (Open Data)](https://go.drugbank.com/releases/latest#open-data) |
+| Ubergraph | [Aggregated data — follows licenses of primary data sources](https://github.com/INCATools/ubergraph?tab=BSD-3-Clause-1-ov-file) |
+| Ensembl gene | [Apache 2.0](https://useast.ensembl.org/info/about/legal/code_licence.html) |
+| BindingDB | [CC BY 3.0 (BindingDB curated), CC BY-SA 3.0 (ChEMBL-derived)](https://www.bindingdb.org/rwd/bind/info.jsp) |
+| DISEASES | [CC BY 4.0](https://diseases.jensenlab.org/About) |
+| NCBI Taxonomy | [CC0 1.0](https://kghub.org/kg-registry/resource/ncbitaxon/ncbitaxon.html) |
+| Human Metabolome Database  | [CC BY 4.0](https://hmdb.ca/about) |
+| Text Mining Targeted Association API | [CC BY 4.0](https://smart-api.info/ui/978fe380a147a8641caf72320862697b) |
+| IntAct | [CC BY 4.0 (all datasets), Software/Tools: Apache License 2.0 (code, web services, curator tools, branding)](https://www.ebi.ac.uk/intact/about#license_privacy) |
+| National Cancer Institute Thesaurus | [CC BY 4.0](https://evs.nci.nih.gov/license) |
+| Bgee | [CC0 1.0](https://www.bgee.org/about/) |
+| Hetionet | [CC BY 4.0](https://het.io/about/) |
+| Medical Subject Headings Thesaurus | [UMLS Metathesaurus](https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf) |
+| Panther Classification System | [CC BY 4.0](https://pantherdb.org/tou.jsp) |
+| Library of Integrated Network-Based Cellular Signatures | [CC BY 4.0](https://lincsportal.ccs.miami.edu/datasets/terms) |
+| Reactome | [CC0 1.0 (All Data), CC BY 4.0 (Pathway art/branding), Apache 2.0 (Software/code - some exceptions)](https://reactome.org/license) |
+| UMLS Metathesaurus (MTH) (from UMLS) | [UMLS Metathesaurus](https://www.nlm.nih.gov/databases/umls.html) |
+| Protein Ontology | [CC BY 4.0](https://obofoundry.org/ontology/pr.html) |
+| DisGeNET | [CC BY 4.0 (for most of its sources)](https://disgenet.com/Legal) |
+| Online Mendelian Inheritance in Man (OMIM) | [Custom Johns Hopkins University OMIM Use Agreement](https://www.omim.org/help/agreement) |
+| Pharos | [Aggregated data — follows licenses of primary data sources](https://pharos.nih.gov/about) |
+| Chemical Entity of Biological Interest | [CC BY 4.0](https://www.ebi.ac.uk/chebi/aboutChebiForward.do) |
+| Human Phenotype Ontology | [Custom HPO License — free use with attribution, version/date display, and no content alteration without approval](https://hpo.jax.org/license) |
+| Gene Ontology Annotations | [CC BY 4.0](https://geneontology.org/docs/go-citation-policy/) |
+| FDA Adverse Event Reporting System | [Public Domain and CC0 1.0](https://open.fda.gov/data/faers/) |
+| Foundational Model of Anatomy Ontology (FMA -- both from UMLS and from OBO) | [CC BY 3.0](http://si.washington.edu/info-books/project-details/foundational-model-of-anatomy/accessing-the-fma-ontology/) |
+| National Center for Biotechnology Information Gene | [CC0 1.0](https://kghub.org/kg-registry/resource/ncbigene/ncbigene.html) |
+| Gene Ontology | [CC BY 4.0](https://geneontology.org/docs/go-citation-policy/) |
+| ICD10PCS (from UMLS) | [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/ICD10PCS) |
+| Tissue Expression Database | [CC BY 4.0](https://tissues.jensenlab.org/About) |
+| Comparative Toxicogenomics Database | [Custom CTD License — free for research/education; commercial use requires written permission; attribution, linking, and usage notification required](https://ctdbase.org/about/legal.jsp) |
+| SIDER | [CC BY-NC-SA 4.0](http://sideeffects.embl.de/about/) |
+| Orphanet | [CC BY 4.0](https://www.orphadata.com/about-us/) |
+| Mouse Genome Informatics | [CC BY 4.0](https://www.informatics.jax.org/mgihome/other/copyright.shtml) |
+| RxNorm | [UMLS Metathesaurus](https://www.nlm.nih.gov/research/umls/rxnorm/faq.html#faq-about-rxnorm) |
+| Medication Reference Terminology (MED-RT) (from UMLS) | [UMLS Metathesaurus](https://evs.nci.nih.gov/ftp1/MED-RT/MED-RT%20Documentation.pdf) |
+| Gene Ontology Plus | [CC BY 4.0](https://geneontology.org/docs/go-citation-policy/) |
+| Foundational Model of Anatomy Ontology (FMA -- both from UMLS and from OBO) | [CC BY 3.0](http://si.washington.edu/info-books/project-details/foundational-model-of-anatomy/accessing-the-fma-ontology/) |
+| ChEMBL | [CC BY-SA 3.0](https://chembl.gitbook.io/chembl-interface-documentation/about) |
+| Veterans Association National Drug File (VANDF) (from UMLS) | [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/VANDF) |
+| Orphanet Rare Disease Ontology | [CC BY 4.0](https://www.orphadata.com/about-us/) |
+| UniProt Knowledgebase | [CC BY 4.0](https://www.uniprot.org/help/license) |
+| Experimental Factor Ontology | [Apache 2.0](https://kghub.org/kg-registry/resource/efo/efo.html) |
+| Drug Gene Interaction Database | [MIT License](https://dgidb.org/about/overview/data-accessibility) |
+| SIGNOR 3.0 | [CC BY 4.0](https://signor.uniroma2.it/) |
+| Food Ontology | [CC BY 4.0](https://obofoundry.org/ontology/foodon.html) |
+| Cell Ontology | [CC BY 4.0](https://obofoundry.org/ontology/cl.html) |
+| HUGO Gene Nomenclature Committee | [Public Domain and CC0](https://www.genenames.org/about/license/) |
+| ICD9CM (from UMLS) | [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/ICD9CM) |
+| DrugCentral | [CC BY-SA 4.0](https://drugcentral.org/privacy) |
+| National Drug Data File (NDDF) (from UMLS) | [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/NDDF) |
+| NCBI Taxonomy Ontology | [CC0 1.0](https://obofoundry.org/ontology/ncbitaxon.html) |
+| Psychological Index Terms (PSY) (from UMLS) | [UMLS Metathesaurus](https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/PSY/stats.html) |
+| Human Phenotype Ontology | [Custom HPO License — free use with attribution, version/date display, and no content alteration without approval](https://hpo.jax.org/license) |
+| Target Illumination GWAS Analytics | [BSD-2-Clause](https://academic.oup.com/bioinformatics/article/37/21/3865/6292081) |
+| MONDO Disease Ontology | [CC BY 4.0](https://mondo.monarchinitiative.org/#license) |
+| Kyoto Encyclopedia of Genes and Genomes (KEGG) | [Proprietary (Kanehisa Laboratories) — free for academic web access; FTP subscription required for academic service use; commercial use requires paid license](https://www.kegg.jp/kegg/legal.html) |
+| Zebrafish Information Network | [CC BY 4.0](https://zfin.atlassian.net/wiki/spaces/general/pages/1942160112/WARRANTY+AND+LIABILITY+DISCLAIMER+OWNERSHIP+AND+LIMITS+ON+USE) |
+| Uber Anatomy Ontology | [CC BY 3.0](https://obofoundry.org/ontology/uberon.html) |
+| Disease Ontology | [CC0 1.0](https://disease-ontology.org/about/) |
+| FlyBase | [CC BY 4.0](https://wiki.flybase.org/wiki/FlyBase:About#FlyBase_Licenses_and_Availability) |
+| Physician Data Query (PDQ) (from UMLS) | [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/PDQ) |
+| Saccharomyces Genome Database | [CC BY 4.0](https://sites.google.com/view/yeastgenome-help/about) |
+| Human Developmental Anatomy Ontology | [CC BY 4.0](https://obofoundry.org/ontology/ehdaa2.html) |
+| DrugMechDB | [CC BY 4.0](https://www.nature.com/articles/s41597-023-02534-z#:~:text=(DrugMechDB)%2C%20a%20manually%20curated&text=Open%20Access%20This%20article%20is%20licensed%20under%20a%20Creative%20Commons%20Attribution%204.0%20International%20License) |
+| Guide to Pharmacology | [CC BY-SA 4.0](https://www.guidetopharmacology.org/download.jsp#:~:text=The%20Guide%20to%20PHARMACOLOGY%20database,Open%20Database%20License%20(ODbL).) |
+| MedlinePlus (from UMLS) | [UMLS Metathesaurus](https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/MEDLINEPLUS/index.html) |
+| Health Level Seven (HL7) (from UMLS) | [UMLS Metathesaurus](https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf) |
+| Drug Repositioning Database | [CC BY 4.0](https://www.nature.com/articles/sdata201729) |
+| Healthcare Common Procedure Coding System (from UMLS) | [UMLS Metathesaurus](https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf) |
+| Anatomical Therapeutic Chemical (ATC) Codes (from UMLS) | [UMLS Metathesaurus](https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf) |
+| eRAM: encyclopedia of rare disease annotations for precision medicine | [Custom eRAM License — free for academic/non-profit use; commercial use requires a paid license; provided “as-is” with no liability](http://119.3.41.228/eram/download.php) |
+| RGD API | [CC BY 4.0](https://rgd.mcw.edu/wg/disclaimer/#:~:text=Data%20in%20RGD%20are%20provided,You%20are%20free%20to%E2%80%A6&text=Adapt:%20remix%2C%20transform%2C%20and,for%20any%20purpose%2C%20even%20commercially.) |
+| Genomic Epidemiology Ontology | [CC BY 3.0](https://obofoundry.org/ontology/genepio.html) |
+| PhosphoSitePlus | [CC BY-NC-SA 3.0](https://www.phosphosite.org/homeAction) |
+| Monarch Initiative | [BSD-3-Clause](https://monarchinitiative.org/kg/terms) |
+| UniChem | [CC BY 4.0](https://www.ebi.ac.uk/training/online/courses/unichem-quick-tour/what-is-unichem/) |
+| The microRNA Database | [Public Domain](https://www.mirbase.org/download/CURRENT/LICENSE/#:~:text=miRBase%20is%20in%20the%20public,MIRBASE%20DATABASE%2C%20EVEN%20IF%20THE) |
+| EPSD | [No License Mentioned](nan) |
+| Phenotype and Trait Ontology | [CC BY 3.0](https://obofoundry.org/ontology/pato.html) |
+| Molecular Interactions Controlled Vocabulary | [CC BY 4.0](https://obofoundry.org/ontology/mi.html) |
+| Neuro Behavior Ontology | [CC BY 3.0](https://bioregistry.io/registry/nbo) |
+| Biolink ontology | [Public Domain and CC0 1.0](https://www.ebi.ac.uk/ols4/ontologies/biolink) |
+| iPTMnet | [CC BY-NC-SA 4.0](https://research.bioinformatics.udel.edu/iptmnet/license) |
+| Psychoactive Drug Screening Program | [CC BY-NC-SA 4.0](https://www.nature.com/nature-index/institution-outputs/articles/all/global/United%20States%20of%20America%20%28USA%29/NIMH%20Psychoactive%20Drug%20Screening%20Program%20%28PDSP%29/) |
+| Relations Ontology | [CC0 1.0](https://obofoundry.org/ontology/ro.html) |
+| Interaction Network Ontology | [CC BY 3.0](https://obofoundry.org/ontology/ino.html) |
+| Biological Spatial Ontology | [CC BY 3.0](https://obofoundry.org/ontology/bspo.html) |
+| Dictyostelium discoideum anatomy | [CC0 1.0](https://bioregistry.io/registry/ddanat) |
+
+
+## Detailed information about each primary knowledge sources
+
+
+### Source: Semantic Medline Database (semmeddb)
+
+_SemMedDB is a repository of semantic predications (subject-predicate-object triples) extracted from biomedical literature by SemRep, a natural language processing system. It contains over 130 million semantic predications extracted from more than 37 million PubMed citations, supporting biomedical knowledge discovery, literature-based discovery, and clinical applications._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/SemMedDB
+- https://lhncbc.nlm.nih.gov/temp/SemRep_SemMedDB_SKR/SemMedDB_download.html
+- https://w3id.org/information-resource-registry/semmeddb
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://academic.oup.com/bioinformatics/article/28/23/3158/195282)
+- **KG Registry**: https://www.nlm.nih.gov/web_policies.html
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+<details><summary>Expand to see detailed review</summary>
+Review information was generated specifically for the Matrix project and may not reflect the views of the broader community.
+
+- **Reviewer**: https://orcid.org/0000-0003-4097-3395
+- **Overall review score**:
+   - Reviewer: `Medium` - SemMedDB is a valuable pharmacology-facing resource because it systematically mines the biomedical literature to surface relationships among drugs, targets, and diseases. For pharmacology and repurposing work, this means one can quickly identify broad patterns of how drugs are reported to treat conditions, inhibit targets, or interact with biological processes across the entire PubMed corpus. The use of UMLS CUIs ensures standardized identifiers and allows integration with other biomedical datasets. However, because the relationships are automatically extracted via NLP rather than manually curated, there is considerable noise, and predicates are often generic. As a result, SemMedDB is best positioned as a hypothesis-generation tool rather than a plug-and-play backbone for drug–disease modeling. With careful filtering around higher-confidence predicates (e.g., TREATS, INHIBITS) and frequency thresholds, it can enrich repurposing pipelines by pointing to candidate mechanisms and literature support at scale
+   - Rubric: `Medium` - Conditional: with condition = “only use curated subsets (e.g., TREATS, INHIBITS) and filter by frequency/confidence
+- **Domain Coverage**: `2` - Entities: drug,target,disease via UMLS CUIs; Relations: TREATS, INHIBITS, ASSOCIATED_WITH (~30 predicate types). Rich coverage but many edges generic/ambiguous.
+- **Source Scope**: `3` - Broad, cross-disease; >21M PubMed citations; 57.6M predications; thousands of drugs, diseases, genes; multi-relation subtypes
+- **Drug Repurposing Utility**: `1` - Direct edges: TREATS, INHIBITS, CAUSES, etc. present but NLP-extracted, noisy; predicates often generic; PubMed links but no confidence scores; precision ~70–80% → heavy filtering required
+</details>
+
+
+### Source: Search Tool for the Retrieval of Interacting Genes/Proteins (string)
+
+_STRING is a database of known and predicted protein-protein interactions. The interactions include direct (physical) and indirect (functional) associations derived from computational prediction, knowledge transfer between organisms, and interactions aggregated from other primary databases._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/STRING
+- https://string-db.org
+- https://string-db.org/
+- https://w3id.org/information-resource-registry/string
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://string-db.org/cgi/access?footer_active_subpage=licensing)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: CC-BY-4.0 (permissive)
+   - _Commentary_: While there are APIs available, we skipped evaluation as they explicitly state they are now meant for bulk use and downloads are available anyways.
+
+#### Review information for this resource
+
+
+<details><summary>Expand to see detailed review</summary>
+Review information was generated specifically for the Matrix project and may not reflect the views of the broader community.
+
+- **Reviewer**: https://orcid.org/0000-0003-4097-3395
+- **Overall review score**:
+   - Reviewer: `High` - STRING is highly relevant for repurposing and translational pharmacology because it captures the functional protein landscape that underlies drug action. By linking proteins in pathways, networks, and disease processes, it enables inference of indirect drug–disease relationships. The layered evidence and confidence scoring help distinguish biologically meaningful interactions from background noise, which is essential for pharmacology-driven hypotheses. Since drugs act through proteins, STRING provides the mechanistic bridge between drug targets and downstream phenotypes, making it a great source for evaluating new therapeutic opportunities
+   - Rubric: `High` - Nominate: as gets A=3 / B=3/ C=3; pretty good source
+- **Domain Coverage**: `3` - Comprehensive gene/protein coverage with dense functional/physical associations and rich UniProt-based descriptors.
+- **Source Scope**: `3` - Global-scale, multi-species PPI/functional knowledgebase with millions of high-confidence edges from heterogeneous evidence.
+- **Drug Repurposing Utility**: `3` - Directly usable as a backbone for repurposing pipelines; confidence-scored PPI edges integrate seamlessly once drug and disease mappings are added.
+</details>
+
+
+### Source: PathWhiz (pathwhiz)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/PathWhiz
+- https://w3id.org/information-resource-registry/pathwhiz
+
+
+#### License information
+
+- **Matrix manual curation**: [David Wishart, Departments of Computing Science & Biological Sciences, University of Alberta.](https://smpdb.ca/pathwhiz)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: DrugBank (drugbank)
+
+_A comprehensive, free-to-access, online database containing information on drugs and drug targets. As both a bioinformatics and a cheminformatics resource, we combine detailed drug (i.e. chemical, pharmacological and pharmaceutical) data with comprehensive drug target (i.e. sequence, structure, and pathway) information_
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/DrugBank
+- https://go.drugbank.com
+- https://w3id.org/information-resource-registry/drugbank
+- https://www.drugbank.com/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY-NC 4.0 (Complete Database including structures, external links, protein identifiers, target sequences, drug sequences), CC0 1.0 (Open Data)](https://go.drugbank.com/releases/latest#open-data)
+- **KG Registry**: https://go.drugbank.com/legal/terms_of_use
+- **Reusable Data**: CC-BY-NC-4.0 (restrictive)
+   - _Issues_: [{'criteria': 'D.1.1', 'comment': 'The NC license allows for liberal non-commercial reuse.'}, {'criteria': 'E.1.1', 'comment': 'The NC license allows for non-commercial reuse with other non-commercial interests.'}]
+   - _Commentary_: There is also an open (CC0) data subset for vocabulary and structures that could be evaluated separately; it is ~5mb vs ~150mb for the complete "academic" set(about 3%).<hr />This seems to be mostly a standard NC/commercial licensing split, with DrugBank+ supporting commerical licensing for fees.<hr />To download the full academic set, one must create an account (https://go.drugbank.com/public_users/sign_up), which is a multi-step and human mediated process, with varying turnaround times and follow-up questions.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Ubergraph (ubergraph)
+
+_A graph representation of Ubergraph, an integration of ontologies including GO, CHEBI, Uberon, and HPO._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Ubergraph
+- https://ubergraph.apps.renci.org/sparql
+- https://w3id.org/information-resource-registry/ubergraph
+
+
+#### License information
+
+- **Matrix manual curation**: [Aggregated data — follows licenses of primary data sources](https://github.com/INCATools/ubergraph?tab=BSD-3-Clause-1-ov-file)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Ensembl gene (ensembl-gene)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/ensembl-gene
+- https://www.ebi.ac.uk/training/online/courses/ensembl-browsing-genomes/exploring-sources-of-biological-data/ensembl-genes/
+
+
+#### License information
+
+- **Matrix manual curation**: [Apache 2.0](https://useast.ensembl.org/info/about/legal/code_licence.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: BindingDB (bindingdb)
+
+_BindingDB is a public, web-accessible database of measured binding affinities, focusing chiefly on the interactions of protein considered to be drug-targets with small, drug-like molecules. As of July 31, 2021, BindingDB contains 41,300 Entries, each with a DOI, containing 2,303,972 binding data for 8,561 protein targets and 995,797 small molecules._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/bindingdb
+- https://w3id.org/information-resource-registry/bindingdb
+- https://www.bindingdb.org/rwd/bind/index.jsp
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0 (BindingDB curated), CC BY-SA 3.0 (ChEMBL-derived)](https://www.bindingdb.org/rwd/bind/info.jsp)
+- **KG Registry**: https://www.bindingdb.org/rwd/bind/info.jsp
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: DISEASES (diseases)
+
+_DISEASES is a weekly updated web resource that integrates evidence on disease-gene associations  from automatic text mining, manually curated literature, cancer mutation data, and  genome-wide association studies. We further unify the evidence by assigning confidence  scores that facilitate comparison of the different types and sources of evidence._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Diseases
+- https://w3id.org/information-resource-registry/diseases
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://diseases.jensenlab.org/About)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+<details><summary>Expand to see detailed review</summary>
+Review information was generated specifically for the Matrix project and may not reflect the views of the broader community.
+
+- **Reviewer**: https://orcid.org/0000-0003-4097-3395
+- **Overall review score**:
+   - Reviewer: `Medium` - The DISEASES database is highly relevant for pharmacology and translational research as it aggregates gene–disease associations from multiple evidence streams — curated resources, GWAS, and large-scale text mining. From a therapeutic perspective, this makes it a powerful backbone for connecting disease biology to molecular targets, especially since all entities are mapped to standardized identifiers (Disease Ontology, UniProt, HGNC, Ensembl). The built-in confidence scoring (1–5 stars) and benchmarking against gold standards lend reliability that is rare in large-scale association resources. For drug repurposing, DISEASES does not provide drug–disease edges directly, but it plays a crucial enabling role: drugs can be linked in through their known targets (via resources like DrugBank or ChEMBL), making D→T→D inference feasible at scale. This indirect but evidence-weighted connection between disease and targets provides a structured way to prioritize repurposing opportunities grounded in genetic and literature support. It is not a plug-and-play repurposing tool on its own, but it is an excellent, trustworthy foundation for building disease–gene–drug networks that support pharmacological hypothesis generation and drug repositioning
+   - Rubric: `Medium` - Conditional: useful for repurposing only when linked with other drug→target resources
+- **Domain Coverage**: `2` - Entities: target,gene + disease; Relation: T–D (~millions); mapped to DOID, STRING/HGNC/Ensembl; confidence scoring robust. No drugs or D–D/AEs.
+- **Source Scope**: `3` - Broad, cross-disease; millions of T–D edges; >19k genes, >8k diseases; integrates curated, GWAS, text mining; updated weekly.
+- **Drug Repurposing Utility**: `2` - Direct edges: T–D; millions of associations; 1–5 star confidence; AUC=0.916 for text mining. No direct drug links, no mechanism or AE context → requires integration with drug–target DBs.
+</details>
+
+
+### Source: NCBI Taxonomy (ncbi-taxonomy)
+
+_No description._
+
+
+**Links**:
+- http://www.ncbi.nlm.nih.gov/taxonomy
+- https://w3id.org/information-resource-registry/ncbi-taxonomy
+
+
+#### License information
+
+- **Matrix manual curation**: [CC0 1.0](https://kghub.org/kg-registry/resource/ncbitaxon/ncbitaxon.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Human Metabolome Database  (hmdb)
+
+_A freely available electronic database containing detailed information about small molecule metabolites found in the human body_
+
+
+**Links**:
+- http://www.hmdb.ca
+- https://github.com/NCATSTranslator/Translator-All/wiki/HMDB
+- https://w3id.org/information-resource-registry/hmdb
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://hmdb.ca/about)
+- **KG Registry**: No license information available.
+- **Reusable Data**: custom (restrictive)
+   - _Issues_: [{'criteria': 'A.2.2', 'comment': 'Custom terms at linked license and on downloads page.'}, {'criteria': 'D.1.1', 'comment': 'The custom license would appear to allow for liberal non-commercial reuse.'}, {'criteria': 'E.1.1', 'comment': 'The custom license would appear to explicitly allow for non-commercial reuse with other non-commercial interests.'}]
+   - _Commentary_: While the terms are minimal, they seem intended to act a bit the CC-BY-NC; it was evaluated similarly.<hr />Given their upstream resources mentioned in http://www.hmdb.ca/sources , it would be interesting to know their pass-through negotiations and differences with Canadian law..
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Text Mining Targeted Association API (text-mining-provider-targeted)
+
+_API serving explicitly targeted Biolink Associations extracted from sentences in the scientific literature. Here, targeted refers to the fact that this service is based on text-mining models targeted to extract specific associations between concepts, as opposed to concepts cooccurring with each other._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Text%E2%80%90mined-Assertion-KP
+- https://w3id.org/information-resource-registry/text-mining-provider-targeted
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://smart-api.info/ui/978fe380a147a8641caf72320862697b)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: IntAct (intact)
+
+_Stub Resource page for intact. This page was automatically generated because it was referenced by other resources._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/IntAct
+- https://w3id.org/information-resource-registry/intact
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0 (all datasets), Software/Tools: Apache License 2.0 (code, web services, curator tools, branding)](https://www.ebi.ac.uk/intact/about#license_privacy)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: National Cancer Institute Thesaurus (ncit)
+
+_Stub Resource page for ncit. This page was automatically generated because it was referenced by other resources._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/NCIT
+- https://ncithesaurus-stage.nci.nih.gov
+- https://w3id.org/information-resource-registry/ncit
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://evs.nci.nih.gov/license)
+- **KG Registry**: No license information available.
+- **Reusable Data**: CC-BY-4.0 (permissive)
+   - _Issues_: []
+   - _Commentary_: The Terms of Use puts a trademark restriction on re-releasing the data using the name "NCI Thesaurus".  This was evaluated as be outside the scope of data (re)use.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Bgee (bgee)
+
+_Bgee is a database for retrieval and comparison of gene expression patterns across multiple animal species, providing information about gene expression in different anatomical structures, developmental stages, and species._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Bgee
+- https://w3id.org/information-resource-registry/bgee
+- https://www.bgee.org
+- https://www.bgee.org/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC0 1.0](https://www.bgee.org/about/)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: CC0-1.0 (permissive)
+   - _Issues_: []
+   - _Commentary_: In footer, two download pages are given in the footer (/download/processed-expression-values and /download/gene-expression-calls) and a third in the menu (/download/data-dumps); on all of these pages we see "All data are available under the Creative Commons Zero license (CC0)."<hr />Also noting that on /about/, there is similarly affirming text.<hr />A little unclear on how this practically interacts with the sources list on /about/sources, but does not affect evaluation with current standards.<hr />While there is manual iteration needed for the TSVs, the mysql and rdf available on the data-dumps page sufficiently bridges the bulk criteria in C.1.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Hetionet (hetionet)
+
+_Hetionet is an integrative network of biomedical knowledge assembled from 29 different databases of genes, compounds, diseases, and more. It combines over 50 years of biomedical information into a single resource._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Hetionet
+- https://het.io/
+- https://w3id.org/information-resource-registry/hetionet
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://het.io/about/)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Medical Subject Headings Thesaurus (mesh)
+
+_Stub Resource page for mesh. This page was automatically generated because it was referenced by other resources._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/MeSH
+- https://w3id.org/information-resource-registry/mesh
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Panther Classification System (panther)
+
+_PANTHER is a Protein ANalysis THrough Evolutionary Relationships Classification System. The mission of the PANTHER knowledgebase is to support biomedical and other research by providing comprehensive information about the evolution of protein-coding gene families, particularly protein phylogeny, function and genetic variation impacting that function._
+
+
+**Links**:
+- http://pantherdb.org/
+- https://github.com/NCATSTranslator/Translator-All/wiki/PANTHER
+- https://w3id.org/information-resource-registry/panther
+- https://www.pantherdb.org/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://pantherdb.org/tou.jsp)
+- **KG Registry**: No license information available.
+- **Reusable Data**: all rights reserved (copyright)
+   - _Issues_: [{'criteria': 'D.1.2', 'comment': 'Given the all rights reserved copyright statement, any downstream reuse would require negotiation.'}, {'criteria': 'E.1.2', 'comment': 'Given the all rights reserved copyright statement, all user/agent types would need to negotiate downstream reuse.'}]
+   - _Commentary_: There is an alternate curation for this resource that bases itself off of 'http://www.pantherdb.org/tou.jsp', which was found using a narrow Google search and not given consideration due to the difficulties in finding it--we have found no access to this document yet except for the Google search.<hr />Considering the alternate license, downloads are under a permissive minimal license that states '...as long as the following copyright statement is placed at the top of each file: Copyright © 2005 SRI International', which besides being likely out of data, is custom and does not cover APIs, remixing, and the like. It is hard to interpret the consequences of this license.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Library of Integrated Network-Based Cellular Signatures (lincs)
+
+_The Library of Integrated Network-based Cellular Signatures (LINCS) is a comprehensive collection of data that catalogs how human cells globally respond to chemical, genetic, and disease perturbations. It aims to better understand human disease and advance the development of new therapies by assembling an integrated picture of the range of responses of human cells exposed to many perturbations._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/LINCS
+- https://lincsportal.ccs.miami.edu/signatures/home
+- https://w3id.org/information-resource-registry/lincs
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://lincsportal.ccs.miami.edu/datasets/terms)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+<details><summary>Expand to see detailed review</summary>
+Review information was generated specifically for the Matrix project and may not reflect the views of the broader community.
+
+- **Reviewer**: https://orcid.org/0000-0003-4097-3395
+- **Overall review score**:
+   - Reviewer: `Medium` - The LINCS program is quite relevant to drug discovery and repurposing because it systematically catalogs how human cells respond to thousands of chemical and genetic perturbations across transcriptomic, proteomic, epigenetic, and imaging assays. From a pharmacology standpoint, this resource provides a unique way to understand mechanism of action, pathway involvement, and potential off-target or toxic effects. While LINCS does not natively contain curated drug–target or drug–disease links, its large-scale perturbation signatures [molecular response profile of a cell when it is exposed to a specific perturbation (e.g., a small molecule, genetic knockdown, overexpression, or other intervention)] serve as a critical hypothesis-generation layer. By integrating LINCS with drug–target resources (e.g., DrugBank, ChEMBL) and disease ontologies, one can systematically prioritize candidate therapies, explore polypharmacology, and filter out compounds with toxicity
+   - Rubric: `Medium` - Conditional: it’s a backbone-scale perturbation resource that’s excellent for signature-based repurposing and MOA illumination, but it must be joined to curated drug–target and disease sources to drive actionable D→D decisions.
+- **Domain Coverage**: `2` - Entities: drugs + genes (genetic perturbations), disease mainly as context; relations are perturbation→signature (L1000, P100/GCP, imaging). Rich metadata/FAIR, but no native D–T/T–D/D–D edges
+- **Source Scope**: `3` - Broad, cross-disease & multi-modality (L1000, proteomics, imaging, epigenetics); tens of thousands of perturbagens; hundreds of thousands of signatures; large multi-center program; FAIR & standardized.”
+- **Drug Repurposing Utility**: `2` - Strong for signature-based D→D (reversal/mimic) via CLUE/L1000CDS2; toxicity signatures (DToxS) aid filtering. Lacks curated D–T/T–D/D–D edges; needs join to DrugBank/ChEMBL/BindingDB and disease resources.
+</details>
+
+
+### Source: Reactome (reactome)
+
+_Reactome from Biopax_
+
+
+**Links**:
+- http://www.reactome.org
+- https://github.com/NCATSTranslator/Translator-All/wiki/reactome
+- https://reactome.org
+- https://w3id.org/information-resource-registry/reactome
+
+
+#### License information
+
+- **Matrix manual curation**: [CC0 1.0 (All Data), CC BY 4.0 (Pathway art/branding), Apache 2.0 (Software/code - some exceptions)](https://reactome.org/license)
+- **KG Registry**: No license information available.
+- **Reusable Data**: CC-BY-4.0 (permissive)
+   - _Issues_: [{'criteria': 'B.2.2', 'comment': 'KEGG gene and pathway annotations used to construct Reactome Functional Interaction (FI) Network are not licenced CC-BY-4.0. There is a comment that "the recipient may not distribute this data to other users without a license from Pathway Solutions, Inc."'}]
+   - _Commentary_: The issue with criteria B.2.2 could be rectified if Reactome provided a clean copy of the data that can be redistributed without negotiation.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: UMLS Metathesaurus (MTH) (from UMLS) (umls-metathesaurus)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/umls-metathesaurus
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/MTH/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://www.nlm.nih.gov/databases/umls.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+<details><summary>Expand to see detailed review</summary>
+Review information was generated specifically for the Matrix project and may not reflect the views of the broader community.
+
+- **Reviewer**: https://orcid.org/0000-0003-4097-3395
+- **Overall review score**:
+   - Reviewer: `High` - Although the rubric yields Conditional due to a Utility score of 2, UMLS is being elevated to Nominate status. Its unparalleled breadth across ~60 integrated vocabularies, extensive coverage of diseases, drugs, phenotypes, anatomy, and genomic entities, and its role as the canonical backbone for biomedical concept normalization make it a uniquely valuable resource. While it lacks curated instance-level D–D edges, its semantic network (134 semantic types, 54 relation families) provides strong relation templates and consistent categorization, enabling cross-walks and harmonization critical for downstream repurposing models—meriting Nmination despite a rubric-derived Conditional
+   - Rubric: `Medium` - Conditional: due to a Utility score of 2
+- **Domain Coverage**: `3` - Covers diseases, drugs/chemicals, genes/genomes, anatomy, phenotypes, procedures, functions; concepts standardized to CUIs with 134 semantic types and 54 relation families.
+- **Source Scope**: `3` - Unifies ~60 vocabularies (~900k concepts) spanning clinical medicine and life sciences, from MeSH and SNOMED to NCBI Taxonomy and early GO integration.
+- **Drug Repurposing Utility**: `2` - Provides schema-level relations (e.g., ‘Pharmacologic Substance TREATS Disease or Syndrome’, ‘interacts with’) but not instance-level curated edges, so mainly useful for normalization and relation templates.
+</details>
+
+
+### Source: Protein Ontology (pr)
+
+_Stub Resource page for pr. This page was automatically generated because it was referenced by other resources._
+
+
+**Links**:
+- https://proconsortium.org/
+- https://w3id.org/information-resource-registry/pr
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://obofoundry.org/ontology/pr.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: DisGeNET (disgenet)
+
+_DisGeNET is the world's largest and most extensive gene-disease association (GDA) network, integrating data from expert-curated repositories, GWAS catalogs, animal models, and scientific literature. It contains gene-disease associations, variant-disease associations, and disease-disease associations with extensive evidence supporting each connection._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/DisGeNET
+- https://w3id.org/information-resource-registry/disgenet
+- https://www.disgenet.com/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0 (for most of its sources)](https://disgenet.com/Legal)
+- **KG Registry**: https://www.disgenet.com/Legal
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Online Mendelian Inheritance in Man (OMIM) (omim)
+
+_OMIM (Online Mendelian Inheritance in Man) is a continuously updated, expert-curated catalog of human genes and genetic disorders, focusing on genotype–phenotype relationships and the molecular basis of disease._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/OMIM
+- https://w3id.org/information-resource-registry/omim
+- https://www.omim.org
+- https://www.omim.org/
+
+
+#### License information
+
+- **Matrix manual curation**: [Custom Johns Hopkins University OMIM Use Agreement](https://www.omim.org/help/agreement)
+- **KG Registry**: https://www.omim.org/help/agreement
+- **Reusable Data**: custom (restrictive)
+   - _Issues_: [{'criteria': 'A.2.2', 'comment': 'The license at link is custom.'}, {'criteria': 'B.1', 'comment': 'Agreement section 13 requires downloads to be updated by downstream; section 14 discussion arbitrary API key revocation.'}, {'criteria': 'C.2', 'comment': 'Downloads and access are provided post-registration; as the API key is used for access control, it violates the C.2 example.'}, {'criteria': 'D.1.2', 'comment': 'Sections 8, 9, and 10 of the agreement make it seems that while a non-profit reasearcher may access the data, there is no reuse (pass-through) possible.'}, {'criteria': 'E.1.2', 'comment': 'Sections 8, 9, and 10 of the agreement make it seems that while a non-profit reasearcher may access the data, there is no reuse (pass-through) possible.'}]
+   - _Commentary_: Assuming that one registered, it seems that data access would be relatively pain-free; so no C.1 violation.<hr />See also: https://omim.org/downloads and https://omim.org/api for additional access information.<hr />It is worth reading through the linked agreement; there are many sections that are restrictive or would be best interpreted with legal advice.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Pharos (pharos)
+
+_focusing on three of the most commonly drug-targeted protein families: G-protein-coupled receptors (GPCRs, Ion channels (ICs), Kinases_
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Pharos
+- https://pharos.nih.gov/
+- https://w3id.org/information-resource-registry/pharos
+
+
+#### License information
+
+- **Matrix manual curation**: [Aggregated data — follows licenses of primary data sources](https://pharos.nih.gov/about)
+- **KG Registry**: No license information available.
+- **Reusable Data**: inconsistent (unknown)
+   - _Issues_: [{'criteria': 'A.1.1', 'comment': 'While any novel data is under a CC license (CC-BY-SA-4.0), the integrated resources are under whatever license the upstream is, with the user expected to sort it out.'}]
+   - _Commentary_: Unfortunately, the API ToS link leads to a bad (404-type) Swagger page.<hr />From the license page: \"Please note that TCRD incoporates many data sources with a variety of associated licenses...Users of the TCRD downloads are resposible for compliance with these licenses.\"<hr />Given the variety and terms of the upstream resources, the inconsistency is not unexpected.<hr />The license is also found here at https://pharos.nih.gov/idg/about, which has similar wording to the README on the downloads page, but makes no note of the user responsibility to adhere to licenses from original data sources.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Chemical Entity of Biological Interest (chebi)
+
+_a freely available dictionary of molecular entities focused on ‘small’ chemical compounds_
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/ChEBI
+- https://w3id.org/information-resource-registry/chebi
+- https://www.ebi.ac.uk/chebi/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://www.ebi.ac.uk/chebi/aboutChebiForward.do)
+- **KG Registry**: https://creativecommons.org/licenses/by-sa/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+<details><summary>Expand to see detailed review</summary>
+Review information was generated specifically for the Matrix project and may not reflect the views of the broader community.
+
+- **Reviewer**: https://orcid.org/0000-0003-4097-3395
+- **Overall review score**:
+   - Reviewer: `Medium` - ChEBI is an essential foundation for biomedical informatics because it provides a rigorously curated ontology of small molecules, drugs, metabolites, cofactors, and xenobiotics, each linked with standardized identifiers (InChI, SMILES, INNs, synonyms) and roles such as “antineoplastic agent” or “analgesic.” From a pharmacology perspective, this makes it an amazing source for harmonizing chemical vocabularies across databases and for ensuring consistent mapping of drug entities when integrating resources like ChEMBL, DrugBank, or Reactome. However, ChEBI does not itself provide direct therapeutic relationships such as drug–target, target–disease, or drug–disease edges. Its value in repurposing therefore lies in its ability to unify chemical definitions, facilitate cross-resource linkage, and provide chemical role annotations that can serve as indirect signals of therapeutic potential. In practice, ChEBI acts as the chemical backbone of larger repurposing pipelines, enabling clean integration rather than producing repurposing hypotheses on its own
+   - Rubric: `Medium` - Conditional: a backbone ontology for chemical harmonization and roles, but requires integration with drug–target and disease resources to support repurposing models.
+- **Domain Coverage**: `2` - Rich ontology of small molecules with roles and structure descriptors; cross-referenced broadly; but lacks explicit gene/disease edges.
+- **Source Scope**: `3` - General-purpose backbone ontology of small molecules, roles, and classes; >400k entities; multi-resource integration; cross-disease, multi-use.
+- **Drug Repurposing Utility**: `1` - Great for harmonization (IDs, synonyms, chemical roles), but lacks curated D–T, T–D, or D–D edges; not plug-and-play for repurposing.
+</details>
+
+
+### Source: Human Phenotype Ontology (hpo-annotations)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/HPO-Annotations
+- https://w3id.org/information-resource-registry/hpo-annotations
+
+
+#### License information
+
+- **Matrix manual curation**: [Custom HPO License — free use with attribution, version/date display, and no content alteration without approval](https://hpo.jax.org/license)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Gene Ontology Annotations (goa)
+
+_No description._
+
+
+**Links**:
+- http://www.geneontology.org/
+- https://w3id.org/information-resource-registry/goa
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://geneontology.org/docs/go-citation-policy/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: FDA Adverse Event Reporting System (faers)
+
+_The FDA Adverse Event Reporting System (FAERS) is a database that contains information on adverse event and medication error reports submitted to FDA._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/FAERS
+- https://w3id.org/information-resource-registry/faers
+
+
+#### License information
+
+- **Matrix manual curation**: [Public Domain and CC0 1.0](https://open.fda.gov/data/faers/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Foundational Model of Anatomy Ontology (FMA -- both from UMLS and from OBO) (fma-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/fma-umls
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/FMA/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0](http://si.washington.edu/info-books/project-details/foundational-model-of-anatomy/accessing-the-fma-ontology/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: National Center for Biotechnology Information Gene (ncbi-gene)
+
+_Gene integrates information from a wide range of species. A record may include nomenclature, Reference Sequences (RefSeqs), maps, pathways, variations, phenotypes, and links to genome-, phenotype-, and locus-specific resources worldwide._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/ncbi-gene
+- https://w3id.org/information-resource-registry/ncbi-gene
+- https://www.ncbi.nlm.nih.gov/gene/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC0 1.0](https://kghub.org/kg-registry/resource/ncbigene/ncbigene.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: inconsistent (unknown)
+   - _Issues_: [{'criteria': 'A.1.1', 'comment': 'The license apparently uses language to declare something similar to "public domain", but with the caveat that it may contain data that is otherwise. This is judged to be a violation as any (re)use would depend on negotiating with all upstream copyright holders, which are not presented. It is implied that their license does not cover all data and could not find an explicit "clean" version of the data in the downloads.'}]
+   - _Commentary_: We specifically avoided the more general operation of the EUtils suite, focusing on the provided downloads.<hr />The following statements from the license page seem to support a custom "hands off" approach. To was difficult to decide if this was "restrictive" or "unknown" (although inconsistent in practice).<hr />...NCBI itself places no restrictions on the use or distribution of the data contained therein. Nor do we accept data when the submitter has requested restrictions on reuse or redistribution...<hr />...some submitters of the original data...may claim patent, copyright, or other intellectual property rights in all or a portion of the data (that has been submitted)...<hr />...NCBI cannot provide comment or unrestricted permission concerning the use, copying, or distribution of the information contained in the molecular databases...
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Gene Ontology (go)
+
+_The Gene Ontology resource, the world’s largest source of information on the functions of genes. This knowledge is both human-readable and machine-readable, and is a foundation for computational analysis of large-scale molecular biology and genetics experiments in biomedical research._
+
+
+**Links**:
+- https://geneontology.org/
+- https://github.com/NCATSTranslator/Translator-All/wiki/go
+- https://w3id.org/information-resource-registry/go
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://geneontology.org/docs/go-citation-policy/)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: ICD10PCS (from UMLS) (icd10pcs-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/icd10pcs-umls
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ICD10PCS/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/ICD10PCS)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Tissue Expression Database (tissues-expression-db)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Tissue-Expression-Database
+- https://w3id.org/information-resource-registry/tissues-expression-db
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://tissues.jensenlab.org/About)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Comparative Toxicogenomics Database (ctd)
+
+_A robust, publicly available database that aims to advance understanding about how environmental exposures affect human health._
+
+
+**Links**:
+- http://ctdbase.org
+- https://ctdbase.org/
+- https://github.com/NCATSTranslator/Translator-All/wiki/CTD
+- https://w3id.org/information-resource-registry/ctd
+
+
+#### License information
+
+- **Matrix manual curation**: [Custom CTD License — free for research/education; commercial use requires written permission; attribution, linking, and usage notification required](https://ctdbase.org/about/legal.jsp)
+- **KG Registry**: https://ctdbase.org/about/legal.jsp
+- **Reusable Data**: custom (restrictive)
+   - _Issues_: [{'criteria': 'A.2.2', 'comment': 'Custom license with interesting use restrictions.'}, {'criteria': 'B.1', 'comment': 'For quality control purposes, you must provide CTD with periodic access to your publication of our data.'}, {'criteria': 'D.1.2', 'comment': 'Given the four statements in the Additional Terms of Data Use, notably number 4, it looks like any downstream user would have to renegotiate with CTD.'}, {'criteria': 'E.1.1', 'comment': 'Without negotiation: "It is to be used only for research and educational purposes."'}]
+   - _Commentary_: There are statements made in the Additional Terms of Data Use that would make it very difficult to re-use the data provided without a air amount o coordination with the resource and changes to information handling.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: SIDER (sider)
+
+_SIDER (Side Effect Resource) contains information on marketed medicines and their recorded adverse drug reactions. The information is extracted from public documents and package inserts, including side effect frequency, drug and side effect classifications, and links to further information._
+
+
+**Links**:
+- http://sideeffects.embl.de/
+- https://github.com/NCATSTranslator/Translator-All/wiki/SIDER
+- https://w3id.org/information-resource-registry/sider
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY-NC-SA 4.0](http://sideeffects.embl.de/about/)
+- **KG Registry**: https://creativecommons.org/licenses/by-nc-sa/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Orphanet (orphanet)
+
+_Orphanet is a unique resource for information and data on rare diseases and orphan drugs, aimed at improving diagnosis, care, and treatment of patients with rare diseases. It maintains the Orphanet rare disease nomenclature (ORPHAcodes), which is essential for improving the visibility of rare diseases in health and research information systems._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/orphanet
+- https://www.orpha.net
+- https://www.orpha.net/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://www.orphadata.com/about-us/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Mouse Genome Informatics (mgi)
+
+_MGI is the international database resource for the laboratory mouse, providing integrated genetic, genomic, and biological data to facilitate the study of human health and disease._
+
+
+**Links**:
+- http://www.informatics.jax.org/
+- https://github.com/NCATSTranslator/Translator-All/wiki/mgi
+- https://w3id.org/information-resource-registry/mgi
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://www.informatics.jax.org/mgihome/other/copyright.shtml)
+- **KG Registry**: No license information available.
+- **Reusable Data**: custom (permissive)
+   - _Issues_: [{'criteria': 'A.2.2', 'comment': 'Custom license.'}, {'criteria': 'E.1.1', 'comment': 'distinguishes groups, allowing for research/academic. Commercial groups can negotiate.'}]
+   - _Commentary_: -This software and data are provided to enhance knowledge and encourage progress in the scientific community and are to be used only for research and educational purposes.<hr />-Any reproduction or use for commercial purpose is prohibited without the prior express written permission of the Jackson Laboratory.
+
+#### Review information for this resource
+
+
+<details><summary>Expand to see detailed review</summary>
+Review information was generated specifically for the Matrix project and may not reflect the views of the broader community.
+
+- **Reviewer**: https://orcid.org/0000-0003-4097-3395
+- **Overall review score**:
+   - Reviewer: `Medium` - MGI provides well-curated links between mouse genes, phenotypes, and human diseasesusing standard ontologies and published evidence. This makes it a strong reference for understanding disease mechanisms and validating target–disease associations. For drug repurposing, MGI is most useful when combined with drug–target databases, since it does not include drugs directly. It supports the pathway from drug → target → disease by supplying reliable target–disease information
+   - Rubric: `Medium` - Conditional — Use MGI’s T–D as high-quality disease biology and gene-prior layer; combine with D–T from DrugBank/ChEMBL/BindingDB to run D→T→D paths. (Consider filtering to curated HMDC disease links.)
+- **Domain Coverage**: `2` - Entities: gene, disease, phenotype; Relations: gene–phenotype (MP), mouse model→human disease (DO/OMIM), gene→GO, gene→expression (GXD); IDs: MGI/DO/MP/NCBI/PMID.
+- **Source Scope**: `3` - Backbone mouse resource; cross-disease; many phenotypes/models; multiple relation subtypes (phenotype, expression, GO, disease models); regular releases / bulk access.
+- **Drug Repurposing Utility**: `2` - Direct edges: T–D (mouse model→human disease) with PMIDs; IDs clean (DO/OMIM/NCBI/MGI). No D–T/D–D/AE—needs drug databases for D→T→D.
+</details>
+
+
+### Source: RxNorm (rxnorm)
+
+_normalized names for clinical drugs and links its names to many of the drug vocabularies commonly used in pharmacy management and drug interaction software, including those of First Databank, Micromedex, and Gold Standard Drug Database_
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/RxNORM
+- https://w3id.org/information-resource-registry/rxnorm
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://www.nlm.nih.gov/research/umls/rxnorm/faq.html#faq-about-rxnorm)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Medication Reference Terminology (MED-RT) (from UMLS) (medrt-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/medrt-umls
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/MED-RT/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://evs.nci.nih.gov/ftp1/MED-RT/MED-RT%20Documentation.pdf)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Gene Ontology Plus (go-plus)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/GO-Plus
+- https://w3id.org/information-resource-registry/go-plus
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://geneontology.org/docs/go-citation-policy/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Foundational Model of Anatomy Ontology (FMA -- both from UMLS and from OBO) (fma-obo)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/fma-obo
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/FMA/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0](http://si.washington.edu/info-books/project-details/foundational-model-of-anatomy/accessing-the-fma-ontology/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: ChEMBL (chembl)
+
+_a manually knowledge_assertion database of bioactive molecules with drug-like properties._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/ChEMBL
+- https://w3id.org/information-resource-registry/chembl
+- https://www.ebi.ac.uk/chembl/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY-SA 3.0](https://chembl.gitbook.io/chembl-interface-documentation/about)
+- **KG Registry**: https://creativecommons.org/licenses/by-sa/3.0/
+- **Reusable Data**: CC-BY-SA-3.0 (copyleft)
+   - _Issues_: [{'criteria': 'D.1.2', 'comment': 'CC SA prevents some types of reuse, such and modification and redistribution with data from different license types.'}, {'criteria': 'E.1.2', 'comment': 'CC SA prevents all parties from reusing the data as D.1.2.'}]
+   - _Commentary_: There was no centralized licensing/terms information on the main site, but all download FTP directories we looked at contained terms for the CC SA 3.0; we used as single example as the license link.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Veterans Association National Drug File (VANDF) (from UMLS) (vandf-umls)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/VANDF
+- https://w3id.org/information-resource-registry/vandf-umls
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/VANDF)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Orphanet Rare Disease Ontology (ordo)
+
+_The Orphanet Rare Disease Ontology (ORDO) is an open-access ontology developed from the Orphanet information system, enabling complex queries of rare diseases and their epidemiological data (age of onset, prevalence, mode of inheritance) and gene-disorder functional relationships._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Orphanet-Rare-Disease-Ontology
+- https://w3id.org/information-resource-registry/ordo
+- https://www.orphadata.com/ordo/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://www.orphadata.com/about-us/)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: UniProt Knowledgebase (uniprot)
+
+_UniProt Protein Knowledge Base_
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/UniProt
+- https://w3id.org/information-resource-registry/uniprot
+- https://www.uniprot.org/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://www.uniprot.org/help/license)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Experimental Factor Ontology (efo)
+
+_The Experimental Factor Ontology (EFO) provides a systematic description of many experimental variables available in EBI databases, and for projects such as the GWAS catalog. It combines parts of several biological ontologies, such as UBERON anatomy, ChEBI chemical compounds, and Cell Ontology._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/EFO
+- https://w3id.org/information-resource-registry/efo
+- https://www.ebi.ac.uk/efo/
+
+
+#### License information
+
+- **Matrix manual curation**: [Apache 2.0](https://kghub.org/kg-registry/resource/efo/efo.html)
+- **KG Registry**: https://www.apache.org/licenses/LICENSE-2.0
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Drug Gene Interaction Database (dgidb)
+
+_information on drug-gene interactions and druggable genes from publications, databases, and other web-based sources. Drug, gene, and interaction data are normalized and merged into conceptual groups._
+
+
+**Links**:
+- https://dgidb.org
+- https://github.com/NCATSTranslator/Translator-All/wiki/dgidb
+- https://w3id.org/information-resource-registry/dgidb
+
+
+#### License information
+
+- **Matrix manual curation**: [MIT License](https://dgidb.org/about/overview/data-accessibility)
+- **KG Registry**: https://opensource.org/licenses/MIT
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: SIGNOR 3.0 (signor)
+
+_SIGNOR (SIGnaling Network Open Resource) is a manually curated repository of experimentally supported, causal relationships between human proteins and other biologically relevant entities (chemicals, phenotypes, complexes, families, stimuli). Each interaction is annotated with effect, mechanism, directionality, evidence (PMID), and a relevance score, enabling construction and analysis of signed, directed signaling networks and pathways. Cite SIGNOR (Lo Surdo et al., 2022 NAR) when using data; interaction data are directional and signed—verify effect/mechanism fields when integrating._
+
+
+**Links**:
+- https://signor.uniroma2.it/
+- https://w3id.org/information-resource-registry/signor
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://signor.uniroma2.it/)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Food Ontology (foodon)
+
+_No description._
+
+
+**Links**:
+- http://www.obofoundry.org/ontology/foodon.html
+- https://w3id.org/information-resource-registry/foodon
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://obofoundry.org/ontology/foodon.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Cell Ontology (cl)
+
+_The Cell Ontology (CL) is a structured controlled vocabulary for cell types in animals. It serves as a comprehensive resource for model organism and bioinformatics databases, with over 2,700 cell type classes and rich integration with other biomedical ontologies._
+
+
+**Links**:
+- https://cell-ontology.github.io/
+- https://github.com/NCATSTranslator/Translator-All/wiki/CL
+- https://w3id.org/information-resource-registry/cl
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://obofoundry.org/ontology/cl.html)
+- **KG Registry**: http://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: HUGO Gene Nomenclature Committee (hgnc)
+
+_HGNC is the HUGO Gene Nomenclature Committee. It is a resource for approved human gene names._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/HGNC
+- https://w3id.org/information-resource-registry/hgnc
+- https://www.genenames.org/
+
+
+#### License information
+
+- **Matrix manual curation**: [Public Domain and CC0](https://www.genenames.org/about/license/)
+- **KG Registry**: https://creativecommons.org/publicdomain/zero/1.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: ICD9CM (from UMLS) (icd9cm-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/icd9cm-umls
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ICD9CM/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/ICD9CM)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: DrugCentral (drugcentral)
+
+_Online drug information resource created and maintained by Division of Translational Informatics at University of New Mexico in collaboration with the IDG._
+
+
+**Links**:
+- http://drugcentral.org
+- https://drugcentral.org/
+- https://github.com/NCATSTranslator/Translator-All/wiki/DrugCentral
+- https://w3id.org/information-resource-registry/drugcentral
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY-SA 4.0](https://drugcentral.org/privacy)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: CC-BY-SA-4.0 (copyleft)
+   - _Issues_: [{'criteria': 'D.1.2', 'comment': 'By using a copyleft-style license, there may be issues in mixing and redistributing this data with licenses that have incompatible terms.'}, {'criteria': 'E.1.2', 'comment': 'By using a copyleft-style license, there may be some parties with issues in mixing and redistributing this data with licenses that have incompatible terms.'}]
+   - _Commentary_: While there is upstream data integtration, there seems to be no mention of upstream licenses or terms. Not necessarily our issue here.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: National Drug Data File (NDDF) (from UMLS) (nddf-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/nddf-umls
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/NDDF)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: No name (chv-umls)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Automat
+- https://w3id.org/information-resource-registry/chv-umls
+
+
+#### License information
+
+- **Matrix manual curation**: [nan](nan)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: NCBI Taxonomy Ontology (ncbi-taxon)
+
+_No description._
+
+
+**Links**:
+- http://www.obofoundry.org/ontology/ncbitaxon.html
+- https://w3id.org/information-resource-registry/ncbi-taxon
+
+
+#### License information
+
+- **Matrix manual curation**: [CC0 1.0](https://obofoundry.org/ontology/ncbitaxon.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Psychological Index Terms (PSY) (from UMLS) (psy-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/psy-umls
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/PSY/index.html#:~:text=PSY%20(Psychological%20Index%20Terms)%20%2D%20Synopsis,-Synopsis%20Metadata%20Statistics&text=The%20Thesaurus%20of%20Psychological%20Index%20Terms%20is%20a%20controlled%20vocabulary,provide%20subject%20searching%20of%20data.
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/PSY/stats.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Human Phenotype Ontology (hpo)
+
+_A curated database of human hereditary syndromes from OMIM, Orphanet, and DECIPHER mapped to classes of the human phenotype ontology. Various meta-attributes such as frequency, references and negations are associated with each annotation. These are presently limited to rare mendelian diseases._
+
+
+**Links**:
+- http://human-phenotype-ontology.github.io
+- https://github.com/NCATSTranslator/Translator-All/wiki/HPO
+- https://w3id.org/information-resource-registry/hpo
+
+
+#### License information
+
+- **Matrix manual curation**: [Custom HPO License — free use with attribution, version/date display, and no content alteration without approval](https://hpo.jax.org/license)
+- **KG Registry**: No license information available.
+- **Reusable Data**: custom (restrictive)
+   - _Issues_: [{'criteria': 'A.2.2', 'comment': 'HPO is copyrighted to protect ontologies and all changes must be made by hpo developers.'}, {'criteria': 'D.1.2', 'comment': 'Restricted downstream use. May not be edited.'}, {'criteria': 'E.1.2', 'comment': 'Restricted downstream use translates to agents as well.'}]
+   - _Commentary_: immutability<hr />unclear derivatives<hr />That the Human Phenotype Ontology Consortium is acknowledged and cited properly.<hr />That neither the content of the HPO file(s) nor the logical relationships embedded within the HPO file(s) be altered in any way.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Target Illumination GWAS Analytics (tiga)
+
+_Aggregating and assessing experimental evidence for interpretable, explainable, accountable gene-trait associations._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/TIGA
+- https://w3id.org/information-resource-registry/tiga
+
+
+#### License information
+
+- **Matrix manual curation**: [BSD-2-Clause](https://academic.oup.com/bioinformatics/article/37/21/3865/6292081)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: MONDO Disease Ontology (mondo)
+
+_The Mondo Disease Ontology (Mondo) aims to harmonize disease definitions across the world. The name Mondo comes from the Latin word ‘mundus’ and means ‘for the world.’_
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/mondo
+- https://mondo.monarchinitiative.org/
+- https://w3id.org/information-resource-registry/mondo
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://mondo.monarchinitiative.org/#license)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Kyoto Encyclopedia of Genes and Genomes (KEGG) (kegg)
+
+_The Kyoto Encyclopedia of Genes and Genomes (KEGG) is a database resource for understanding high-level functions and utilities of the biological system, such as the cell, the organism and the ecosystem, from molecular-level information, especially large-scale molecular datasets generated by genome sequencing and other high-throughput experimental technologies._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/kegg
+- https://www.genome.jp/kegg/
+
+
+#### License information
+
+- **Matrix manual curation**: [Proprietary (Kanehisa Laboratories) — free for academic web access; FTP subscription required for academic service use; commercial use requires paid license](https://www.kegg.jp/kegg/legal.html)
+- **KG Registry**: https://www.kegg.jp/feedback/copyright.html
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Zebrafish Information Network (zfin)
+
+_Zebrafish Information Network, including the Zebrafish Anatomical Ontology_
+
+
+**Links**:
+- http://zfin.org
+- https://w3id.org/information-resource-registry/zfin
+- https://zfin.org/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://zfin.atlassian.net/wiki/spaces/general/pages/1942160112/WARRANTY+AND+LIABILITY+DISCLAIMER+OWNERSHIP+AND+LIMITS+ON+USE)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: custom (restrictive)
+   - _Issues_: [{'criteria': 'A.2.2', 'comment': 'Custom license with non-academic and non-research use restrictions.'}, {'criteria': 'B.1', 'comment': 'The license explicity requires intervention for downstream reuse and redistribution.'}, {'criteria': 'D.1.2', 'comment': 'The license requires written permission for redistribution.'}, {'criteria': 'E.1.2', 'comment': 'The license requires written premission for redistribution even for academic and non commerical parties.'}]
+   - _Commentary_: -ZFIN Software and Data are provided to enhance knowledge and encourage progress in the scientific community, and are to be used only for research and educational purposes. ZFIN reserves all rights not expressly granted. Further, ZFIN retains all rights, title, and interest in and to the Software and Data. Any reproduction or use for a commercial purpose is prohibited without the prior express written permission of ZFIN. Distribution of the Software or Data to any third party, without a separate written agreement with ZFIN, is prohibited.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Uber Anatomy Ontology (uberon)
+
+_An integrated cross-species anatomy ontology representing a variety of anatomical structures across taxonomic groups, with a focus on vertebrates and model organisms._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Uberon
+- https://obophenotype.github.io/uberon/
+- https://w3id.org/information-resource-registry/uberon
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0](https://obofoundry.org/ontology/uberon.html)
+- **KG Registry**: https://creativecommons.org/licenses/by/3.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Disease Ontology (disease-ontology)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/disease-ontology
+- https://w3id.org/information-resource-registry/disease-ontology
+
+
+#### License information
+
+- **Matrix manual curation**: [CC0 1.0](https://disease-ontology.org/about/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: FlyBase (flybase)
+
+_A Database of Drosophila Genes & Genomes_
+
+
+**Links**:
+- http://flybase.org
+- https://flybase.org
+- https://w3id.org/information-resource-registry/flybase
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://wiki.flybase.org/wiki/FlyBase:About#FlyBase_Licenses_and_Availability)
+- **KG Registry**: No license information available.
+- **Reusable Data**: custom (restrictive)
+   - _Issues_: [{'criteria': 'A.2.2', 'comment': "Copyright statement includes 'This publication may be copied for non-commercial, scientific uses by individuals or organizations (including for-profit organizations). FlyBase is freely distributed to the scientific community on the understanding that it will not be used for commercial gain by any organization. Any commercial use of this publication, or any parts thereof, is expressly prohibited without permission in writing from the FlyBase consortium.'"}, {'criteria': 'B.1', 'comment': "Copyright statement includes 'Certain portions of FlyBase are copyrighted separately.'"}, {'criteria': 'B.2.1', 'comment': "Copyright statement includes 'Certain portions of FlyBase are copyrighted separately.'"}, {'criteria': 'D.1.1', 'comment': 'As stated copyright may be interpreted by non-legal professional that the contents may be reused/remixed in a non-commercial context.'}, {'criteria': 'E.1.1', 'comment': 'As stated copyright may be interpreted by non-legal professional that the contents may be reused/remixed in a non-commercial context.'}]
+   - _Commentary_: Copyright statement is not co-located with the data source.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Physician Data Query (PDQ) (from UMLS) (pdq-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/pdq-umls
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/PDQ/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://bioportal.bioontology.org/ontologies/PDQ)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Saccharomyces Genome Database (sgd)
+
+_The Saccharomyces Genome Database (SGD) project collects information and maintains a database of the molecular biology of the yeast Saccharomyces cerevisiae._
+
+
+**Links**:
+- http://www.yeastgenome.org/
+- https://w3id.org/information-resource-registry/sgd
+- https://www.yeastgenome.org/
+- https://yeastgenome.org/
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://sites.google.com/view/yeastgenome-help/about)
+- **KG Registry**: No license information available.
+- **Reusable Data**: CC-BY-4.0 (permissive)
+   - _Issues_: [{'criteria': 'B.2.1', 'comment': 'While the downloadable data seems quite clearly CC-BY-4.0, the API footer has terms that indicate that all data may not be covered under the same license (see comments).'}, {'criteria': 'B.2.2', 'comment': 'The API does not seem to be any easy way to differentiate the \\"clean\\" CC-BY-4.0 data from other licenses.'}]
+   - _Commentary_: The license information found in the "About SGD" paragraph on the SGD Help page at https://sites.google.com/view/yeastgenome-help/about<hr />SGD operates under the Creative Commons Attribution 4.0 International license (CC BY 4.0).<hr />However, the license information for the API is much less clear, reading: "Permission to use the information contained in this database was given by the researchers/institutes who contributed or published the information. Users of the database are solely responsible for compliance with any copyright restrictions, including those applying to the author abstracts."<hr />The API did not seem to offer any way of filter out things with other licenses.<hr />Without ascending, noting that various upstream for the SGD API could have other terms: https://yeastmine.yeastgenome.org/yeastmine/dataCategories.do
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Human Developmental Anatomy Ontology (ehdaa2)
+
+_No description._
+
+
+**Links**:
+- http://obofoundry.org/ontology/ehdaa2.html
+- https://w3id.org/information-resource-registry/ehdaa2
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://obofoundry.org/ontology/ehdaa2.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: DrugMechDB (drugmechdb)
+
+_A database of paths that represent the mechanism of action from a drug to a disease in an indication._
+
+
+**Links**:
+- https://github.com/SuLab/DrugMechDB
+- https://sulab.github.io/DrugMechDB/
+- https://w3id.org/information-resource-registry/drugmechdb
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://www.nature.com/articles/s41597-023-02534-z#:~:text=(DrugMechDB)%2C%20a%20manually%20curated&text=Open%20Access%20This%20article%20is%20licensed%20under%20a%20Creative%20Commons%20Attribution%204.0%20International%20License)
+- **KG Registry**: https://creativecommons.org/publicdomain/zero/1.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Guide to Pharmacology (gtopdb)
+
+_An expert-knowledge_assertion resource of ligand-activity-target relationships, the majority of which come from high-quality pharmacological and medicinal chemistry literature_
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/GtoPdb
+- https://w3id.org/information-resource-registry/gtopdb
+- https://www.guidetopharmacology.org
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY-SA 4.0](https://www.guidetopharmacology.org/download.jsp#:~:text=The%20Guide%20to%20PHARMACOLOGY%20database,Open%20Database%20License%20(ODbL).)
+- **KG Registry**: http://creativecommons.org/licenses/by-sa/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: MedlinePlus (from UMLS) (medlineplus)
+
+_No description._
+
+
+**Links**:
+- https://medlineplus.gov/
+- https://w3id.org/information-resource-registry/medlineplus
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/MEDLINEPLUS/index.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Health Level Seven (HL7) (from UMLS) (hl7-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/hl7-umls
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/HL7V3.0/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Drug Repositioning Database (repodb)
+
+_RepoDB is a standard dataset of drug repositioning successes and failures  that can be used to fairly and reproducibly benchmark computational  repositioning methods. The database contains approved drugs, their  indications, and clinical trial outcomes._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/repoDB
+- https://unmtid-shinyapps.net/shiny/repodb/
+- https://w3id.org/information-resource-registry/repodb
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://www.nature.com/articles/sdata201729)
+- **KG Registry**: https://creativecommons.org/licenses/by/4.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Healthcare Common Procedure Coding System (from UMLS) (hcp-codes-umls)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/HCPCS-Version-of-Current-Procedural-Terminology
+- https://w3id.org/information-resource-registry/hcp-codes-umls
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Anatomical Therapeutic Chemical (ATC) Codes (from UMLS) (atc-codes-umls)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/atc-codes-umls
+- https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ATC/index.html
+
+
+#### License information
+
+- **Matrix manual curation**: [UMLS Metathesaurus](https://uts.nlm.nih.gov/uts/assets/LicenseAgreement.pdf)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: eRAM: encyclopedia of rare disease annotations for precision medicine (eram)
+
+_encyclopedia of rare disease annotations for precision medicine_
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/eRAM
+- https://w3id.org/information-resource-registry/eram
+
+
+#### License information
+
+- **Matrix manual curation**: [Custom eRAM License — free for academic/non-profit use; commercial use requires a paid license; provided “as-is” with no liability](http://119.3.41.228/eram/download.php)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: RGD API (rgd)
+
+_The RGD API_
+
+
+**Links**:
+- http://rgd.mcw.edu
+- https://rgd.mcw.edu/
+- https://w3id.org/information-resource-registry/rgd
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://rgd.mcw.edu/wg/disclaimer/#:~:text=Data%20in%20RGD%20are%20provided,You%20are%20free%20to%E2%80%A6&text=Adapt:%20remix%2C%20transform%2C%20and,for%20any%20purpose%2C%20even%20commercially.)
+- **KG Registry**: No license information available.
+- **Reusable Data**: CC-BY-4.0 (permissive)
+   - _Issues_: []
+   - _Commentary_: Information found in the "Legal Disclaimer" footer on all pages, next to CC BY 4.0 link.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Genomic Epidemiology Ontology (genepio)
+
+_No description._
+
+
+**Links**:
+- https://genepio.org/
+- https://w3id.org/information-resource-registry/genepio
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0](https://obofoundry.org/ontology/genepio.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: PhosphoSitePlus (psite-plus)
+
+_provides comprehensive information and tools for the study of protein  post-translational modifications (PTMs) including phosphorylation, acetylation, and more._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/psite-plus
+- https://www.phosphosite.org/homeAction.action
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY-NC-SA 3.0](https://www.phosphosite.org/homeAction)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Monarch Initiative (monarchinitiative)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/Monarch-Initiative
+- https://w3id.org/information-resource-registry/monarchinitiative
+
+
+#### License information
+
+- **Matrix manual curation**: [BSD-3-Clause](https://monarchinitiative.org/kg/terms)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: UniChem (unichem)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/UniChem
+- https://w3id.org/information-resource-registry/unichem
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://www.ebi.ac.uk/training/online/courses/unichem-quick-tour/what-is-unichem/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: The microRNA Database (mirbase)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/mirbase
+- https://www.mirbase.org/
+
+
+#### License information
+
+- **Matrix manual curation**: [Public Domain](https://www.mirbase.org/download/CURRENT/LICENSE/#:~:text=miRBase%20is%20in%20the%20public,MIRBASE%20DATABASE%2C%20EVEN%20IF%20THE)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: EPSD (epsd)
+
+_No description._
+
+
+**Links**:
+- https://epsd.biocuckoo.cn
+- https://w3id.org/information-resource-registry/epsd
+
+
+#### License information
+
+- **Matrix manual curation**: [No License Mentioned](nan)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Phenotype and Trait Ontology (pato)
+
+_Phenotype And Trait Ontology (PATO) is an ontology of phenotypic qualities (properties, attributes or characteristics). It is used in conjunction with other ontologies to refer to phenotypes, and is widely used for logical definitions of phenotypes in cross-species integration._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/PATO
+- https://github.com/pato-ontology/pato/
+- https://w3id.org/information-resource-registry/pato
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0](https://obofoundry.org/ontology/pato.html)
+- **KG Registry**: http://creativecommons.org/licenses/by/3.0/
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Molecular Interactions Controlled Vocabulary (mi)
+
+_Stub Resource page for mi. This page was automatically generated because it was referenced by other resources._
+
+
+**Links**:
+- http://www.obofoundry.org/ontology/mi.html
+- https://w3id.org/information-resource-registry/mi
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 4.0](https://obofoundry.org/ontology/mi.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Neuro Behavior Ontology (nbo)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/NBO
+- https://w3id.org/information-resource-registry/nbo
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0](https://bioregistry.io/registry/nbo)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Biolink ontology (biolink-ontology)
+
+_No description._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/BioLink-OWL
+- https://w3id.org/information-resource-registry/biolink-ontology
+
+
+#### License information
+
+- **Matrix manual curation**: [Public Domain and CC0 1.0](https://www.ebi.ac.uk/ols4/ontologies/biolink)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: iPTMnet (iptmnet)
+
+_iPTMnet is a bioinformatics resource for integrated understanding of protein post-translational modifications (PTMs) in systems biology context. It connects multiple disparate bioinformatics tools and systems text mining, data mining, analysis and visualization tools, and databases and ontologies into an integrated cross-cutting research resource to address the knowledge gaps in exploring and discovering PTM networks._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/iPTMnet
+- https://w3id.org/information-resource-registry/iptmnet
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY-NC-SA 4.0](https://research.bioinformatics.udel.edu/iptmnet/license)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Psychoactive Drug Screening Program (pdsp)
+
+_This service provides screening of novel psychoactive compounds for pharmacological and functional activity at cloned human or rodent CNS receptors, channels, and transporters._
+
+
+**Links**:
+- https://github.com/NCATSTranslator/Translator-All/wiki/PDSP
+- https://w3id.org/information-resource-registry/pdsp
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY-NC-SA 4.0](https://www.nature.com/nature-index/institution-outputs/articles/all/global/United%20States%20of%20America%20%28USA%29/NIMH%20Psychoactive%20Drug%20Screening%20Program%20%28PDSP%29/)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Relations Ontology (ro)
+
+_Stub Resource page for ro. This page was automatically generated because it was referenced by other resources._
+
+
+**Links**:
+- http://www.obofoundry.org/ontology/ro.html
+- https://w3id.org/information-resource-registry/ro
+
+
+#### License information
+
+- **Matrix manual curation**: [CC0 1.0](https://obofoundry.org/ontology/ro.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Interaction Network Ontology (ino)
+
+_No description._
+
+
+**Links**:
+- http://www.obofoundry.org/ontology/ino.html
+- https://w3id.org/information-resource-registry/ino
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0](https://obofoundry.org/ontology/ino.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Biological Spatial Ontology (bspo)
+
+_No description._
+
+
+**Links**:
+- https://obofoundry.org/ontology/bspo.html
+- https://w3id.org/information-resource-registry/bspo
+
+
+#### License information
+
+- **Matrix manual curation**: [CC BY 3.0](https://obofoundry.org/ontology/bspo.html)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: Dictyostelium discoideum anatomy (dda)
+
+_No description._
+
+
+**Links**:
+- http://www.obofoundry.org/ontology/ddanat.html
+- https://w3id.org/information-resource-registry/dda
+
+
+#### License information
+
+- **Matrix manual curation**: [CC0 1.0](https://bioregistry.io/registry/ddanat)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+
+
+### Source: No name (medical team)
+
+_No description._
+
+
+**Links**:
+- https://w3id.org/information-resource-registry/medical team
+
+
+#### License information
+
+- **Matrix manual curation**: [nan](nan)
+- **KG Registry**: No license information available.
+- **Reusable Data**: No license information available.
+
+#### Review information for this resource
+
+
+No review information available.
+


### PR DESCRIPTION
# Description of the changes

Introduces documentation for the MATRIX platform's knowledge graph and adds an (auto-generated) page detailing primary knowledge sources, including licensing and relevancy assessments for drug repurposing. 

This documentation support transparency, attribution requirements for various licences, and information requirements of the medical and data teams (What is this source and why do we have it?).

## Fixes / Resolves the following issues:

- https://linear.app/everycure/issue/XDATA-152
- Note: I have made the pipeline to generate the docs already reproducible, but because we need to close this issue, and the repeatable pipeline corresponds to another issue, I will commit the code to auto-update in a separate PR.

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [X] Made corresponding changes to the documentation
- [ ] ~~Added tests that prove my fix is effective or that my feature works~~
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~
- [ ] ~~If breaking changes occur or you need everyone to run a command locally after~~
    ~~pulling in latest main, uncomment the below "Merge Notification" section and~~
    ~~describe steps necessary for people~~
- [ ] ~~Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))~~

