### PR TITLE
Add dashboard page showing KG stats across releases

### DIFF
--- a/services/kg_dashboard/.gitignore
+++ b/services/kg_dashboard/.gitignore
@@ -10,7 +10,7 @@ static/data
 .env
 .evidence
 .npmrc
-
+sources/bq/release_trends.sql
 
 sources/bq/connection.options.yaml
 *.duckdb

--- a/services/kg_dashboard/Makefile
+++ b/services/kg_dashboard/Makefile
@@ -12,6 +12,8 @@ export EVIDENCE_VAR__release_version := $(RELEASE_VERSION)
 export EVIDENCE_VAR__bq_release_version := $(subst .,_,$(RELEASE_VERSION))
 export VITE_release_version := $(RELEASE_VERSION)
 
+# Previous release comparison is now handled via release_trends.sql
+
 # Build time to show when dashboard was last updated
 export VITE_build_time := $(shell date -u '+%B %d, %Y at %H:%M:%S UTC')
 
@@ -39,7 +41,10 @@ export EVIDENCE_VAR__max_edge_failed_normalization_by_normalization_set_prefix :
 bump_basepath:
 	node ./scripts/update-basepath.cjs $(RELEASE_VERSION)
 
-build: bump_basepath 
+generate-release-sql:
+	RELEASE_VERSION=$(RELEASE_VERSION) PROJECT_ID=$(PROJECT_ID) node ./scripts/generate-release-trends-sql.cjs
+
+build: bump_basepath generate-release-sql
 	@echo "Building with EVIDENCE_VAR__release_version=$(EVIDENCE_VAR__release_version)"
 	npm run build:strict
 
@@ -62,7 +67,7 @@ populate-valid-edge-types-source:
 	rm -f scripts/temp_valid_edge_types.tsv
 
 run-sources: populate-infores-source populate-valid-edge-types-source
-	npm run sources
+	npm run sources 
 
 run-dev:
 	npm run dev

--- a/services/kg_dashboard/pages/release_trends.md
+++ b/services/kg_dashboard/pages/release_trends.md
@@ -1,0 +1,94 @@
+---
+title: Release Trends
+---
+
+<script>
+  const current_release_version = import.meta.env.VITE_release_version;
+  const build_time = import.meta.env.VITE_build_time;
+</script>
+
+# Knowledge Graph Release Trends
+
+This page shows how key metrics have changed across all releases of the MATRIX knowledge graph, with detailed comparisons between the current release ({current_release_version}) and previous versions.
+
+<p class="text-gray-500 text-sm italic">Last updated on {build_time}</p>
+
+```sql release_metrics
+select 
+    semantic_version,
+    bq_version,
+    is_current_release,
+    n_nodes,
+    n_edges,
+    n_distinct_knowledge_sources,
+    edges_per_node,
+    n_nodes_from_disease_list,
+    n_nodes_from_drug_list,
+    nodes_change,
+    edges_change,
+    nodes_pct_change,
+    edges_pct_change
+from 
+    bq.release_trends
+where 
+    -- Only include releases that have data (some may not have overall_metrics table)
+    n_nodes is not null
+    and n_edges is not null
+order by 
+    release_order
+```
+
+## Graph Size Trends
+
+### Nodes and Edges Over Time
+
+<LineChart 
+    data={release_metrics} 
+    x="semantic_version" 
+    y="n_nodes"
+    title="Total Nodes Across Releases"
+    yAxisTitle="Number of Nodes"
+    sort=false
+/>
+
+<LineChart 
+    data={release_metrics} 
+    x="semantic_version" 
+    y="n_edges"
+    title="Total Edges Across Releases" 
+    yAxisTitle="Number of Edges"
+    sort=false
+/>
+
+## Drug and Disease lists over time
+
+<LineChart 
+    data={release_metrics} 
+    x="semantic_version" 
+    y="n_nodes_from_drug_list"
+    title="Drug Nodes Across Releases"
+    yAxisTitle="Number of Drug Nodes"
+    sort=false
+/>
+
+<LineChart 
+    data={release_metrics} 
+    x="semantic_version" 
+    y="n_nodes_from_disease_list"
+    title="Disease Nodes Across Releases" 
+    yAxisTitle="Number of Disease Nodes"
+    sort=false
+/>
+
+## Knowledge Sources
+
+<LineChart 
+    data={release_metrics} 
+    x="semantic_version" 
+    y="n_distinct_knowledge_sources"
+    title="Distinct Knowledge Sources Across Releases"
+    yAxisTitle="Number of Distinct Knowledge Sources"
+    sort=false
+/>
+
+

--- a/services/kg_dashboard/scripts/generate-release-trends-sql.cjs
+++ b/services/kg_dashboard/scripts/generate-release-trends-sql.cjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+
+// Script to generate the release_trends.sql file dynamically
+// based on available BigQuery datasets
+const { BigQuery } = require('@google-cloud/bigquery');
+
+async function generateReleaseTrendsSQL() {
+  const projectId = process.env.PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT;
+  const currentReleaseVersion = process.env.RELEASE_VERSION || 'v0.9.9';
+  
+  if (!projectId) {
+    console.error('Error: PROJECT_ID or GOOGLE_CLOUD_PROJECT environment variable not set');
+    process.exit(1);
+  }
+
+  console.log(`Filtering releases up to current version: ${currentReleaseVersion}`);
+
+  const bigquery = new BigQuery({ projectId });
+
+  try {
+    // Query to find all release datasets (only standard vX_Y_Z pattern, not experimental ones)
+    const query = `
+      SELECT 
+        schema_name as dataset_id,
+        REGEXP_EXTRACT(schema_name, r'^release_(v[0-9]+_[0-9]+_[0-9]+)$') as bq_version,
+        REPLACE(REGEXP_EXTRACT(schema_name, r'^release_(v[0-9]+_[0-9]+_[0-9]+)$'), '_', '.') as semantic_version
+      FROM \`${projectId}.INFORMATION_SCHEMA.SCHEMATA\`
+      WHERE REGEXP_CONTAINS(schema_name, r'^release_v[0-9]+_[0-9]+_[0-9]+$')
+      ORDER BY schema_name
+    `;
+
+    const [rows] = await bigquery.query(query);
+    
+    if (rows.length === 0) {
+      console.error('No release datasets found');
+      process.exit(1);
+    }
+
+    // Parse version numbers for proper numeric sorting and filtering
+    const parseVersion = (version) => {
+      const parts = version.replace('v', '').split('.').map(num => parseInt(num, 10));
+      return parts;
+    };
+    
+    const compareVersions = (a, b) => {
+      const aVersion = parseVersion(a);
+      const bVersion = parseVersion(b);
+      
+      // Compare major, minor, patch in order
+      for (let i = 0; i < Math.max(aVersion.length, bVersion.length); i++) {
+        const aPart = aVersion[i] || 0;
+        const bPart = bVersion[i] || 0;
+        
+        if (aPart !== bPart) {
+          return aPart - bPart;
+        }
+      }
+      
+      return 0;
+    };
+
+    // Filter out releases that are newer than the current release version
+    const filteredReleases = rows.filter(row => {
+      if (!row.bq_version || !row.semantic_version) {
+        return false;
+      }
+      
+      // Only include releases that are <= current release version
+      return compareVersions(row.semantic_version, currentReleaseVersion) <= 0;
+    });
+
+    // Now verify each release has nodes/edges tables by trying to count from them
+    console.log(`Checking ${filteredReleases.length} releases for nodes/edges tables...`);
+    const validReleases = [];
+    
+    for (const release of filteredReleases) {
+      let nodesTable = null;
+      let edgesTable = null;
+      let diseaseTable = null;
+      let drugTable = null;
+      
+      // Try different table name conventions for nodes
+      const nodeTables = ['nodes_unified', 'unified_nodes'];
+      for (const tableName of nodeTables) {
+        try {
+          const testQuery = `SELECT 1 FROM \`${projectId}.${release.dataset_id}.${tableName}\` LIMIT 1`;
+          await bigquery.query(testQuery);
+          nodesTable = tableName;
+          break;
+        } catch (error) {
+          // Table doesn't exist or isn't accessible, try next one
+        }
+      }
+      
+      // Try different table name conventions for edges  
+      const edgeTables = ['edges_unified', 'unified_edges'];
+      for (const tableName of edgeTables) {
+        try {
+          const testQuery = `SELECT 1 FROM \`${projectId}.${release.dataset_id}.${tableName}\` LIMIT 1`;
+          await bigquery.query(testQuery);
+          edgesTable = tableName;
+          break;
+        } catch (error) {
+          // Table doesn't exist or isn't accessible, try next one
+        }
+      }
+      
+      // Check for disease_list_nodes_normalized table
+      try {
+        const testQuery = `SELECT 1 FROM \`${projectId}.${release.dataset_id}.disease_list_nodes_normalized\` LIMIT 1`;
+        await bigquery.query(testQuery);
+        diseaseTable = 'disease_list_nodes_normalized';
+      } catch (error) {
+        // Table doesn't exist or isn't accessible
+      }
+      
+      // Check for drug_list_nodes_normalized table
+      try {
+        const testQuery = `SELECT 1 FROM \`${projectId}.${release.dataset_id}.drug_list_nodes_normalized\` LIMIT 1`;
+        await bigquery.query(testQuery);
+        drugTable = 'drug_list_nodes_normalized';
+      } catch (error) {
+        // Table doesn't exist or isn't accessible
+      }
+      
+      if (nodesTable && edgesTable) {
+        release.nodes_table = nodesTable;
+        release.edges_table = edgesTable;
+        release.disease_table = diseaseTable;
+        release.drug_table = drugTable;
+        validReleases.push(release);
+        console.log(`  ✓ ${release.semantic_version} - found ${nodesTable}, ${edgesTable}${diseaseTable ? ', ' + diseaseTable : ''}${drugTable ? ', ' + drugTable : ''}`);
+      } else {
+        console.log(`  Skipping ${release.semantic_version} - missing tables (nodes: ${nodesTable}, edges: ${edgesTable})`);
+      }
+    }
+    
+    // Sort releases by semantic version (numeric sort, not alphabetic)
+    validReleases.sort((a, b) => compareVersions(a.semantic_version, b.semantic_version));
+    
+    console.log(`Found ${validReleases.length} releases with nodes/edges tables:`, validReleases.map(r => r.semantic_version).join(', '));
+
+    // Generate the SQL with direct counting from nodes/edges tables
+    let sql;
+    if (validReleases.length > 0) {
+      const unionClauses = validReleases.map((release, index) => 
+        `    select 
+      '${release.bq_version}' as bq_version,
+      '${release.semantic_version}' as semantic_version,
+      ${index + 1} as release_order,
+      (select count(*) from \`\${project_id}.${release.dataset_id}.${release.nodes_table}\`) as n_nodes,
+      (select count(*) from \`\${project_id}.${release.dataset_id}.${release.edges_table}\`) as n_edges,
+      (select count(distinct primary_knowledge_source) from \`\${project_id}.${release.dataset_id}.${release.edges_table}\`) as n_distinct_knowledge_sources,
+      cast(null as int64) as n_nodes_without_most_connected_nodes,
+      ${release.disease_table ? `(select count(*) from \`\${project_id}.${release.dataset_id}.${release.disease_table}\`)` : 'cast(null as int64)'} as n_nodes_from_disease_list,
+      ${release.drug_table ? `(select count(*) from \`\${project_id}.${release.dataset_id}.${release.drug_table}\`)` : 'cast(null as int64)'} as n_nodes_from_drug_list,
+      cast(null as int64) as n_edges_without_most_connected_nodes,
+      cast(null as int64) as n_edges_from_disease_list,
+      cast(null as int64) as n_edges_from_drug_list,
+      cast(null as float64) as median_drug_node_degree,
+      cast(null as float64) as median_disease_node_degree`
+      ).join('\n    union all\n');
+
+      sql = `-- Get key metrics across all available releases to show trends over time
+-- This file is auto-generated by scripts/generate-release-trends-sql.js
+-- Last generated: ${new Date().toISOString()}
+-- Using direct counts from nodes/edges tables
+
+with all_release_metrics as (
+${unionClauses}
+)`;
+    } else {
+      // Fallback: create a query that returns no results but has the right schema
+      console.log('No accessible release tables found, creating fallback query...');
+      sql = `-- Get key metrics across all available releases to show trends over time
+-- This file is auto-generated by scripts/generate-release-trends-sql.js
+-- Last generated: ${new Date().toISOString()}
+-- NOTE: No accessible release datasets found, returning empty results
+
+with all_release_metrics as (
+  select 
+    cast(null as string) as bq_version,
+    cast(null as string) as semantic_version,
+    cast(null as int64) as release_order,
+    cast(null as int64) as n_nodes,
+    cast(null as int64) as n_edges,
+    cast(null as int64) as n_distinct_knowledge_sources,
+    cast(null as int64) as n_nodes_without_most_connected_nodes,
+    cast(null as int64) as n_nodes_from_disease_list,
+    cast(null as int64) as n_nodes_from_drug_list,
+    cast(null as int64) as n_edges_without_most_connected_nodes,
+    cast(null as int64) as n_edges_from_disease_list,
+    cast(null as int64) as n_edges_from_drug_list,
+    cast(null as float64) as median_drug_node_degree,
+    cast(null as float64) as median_disease_node_degree
+  where false  -- This ensures no rows are returned
+)`;
+    }
+
+    sql += `
+
+select 
+  semantic_version,
+  bq_version,
+  release_order,
+  -- Mark current release
+  case when bq_version = '\${bq_release_version}' then true else false end as is_current_release,
+  
+  n_nodes,
+  n_edges,
+  n_edges / n_nodes as edges_per_node,
+  n_nodes_from_disease_list,
+  n_nodes_from_drug_list,
+  n_edges_from_disease_list,
+  n_edges_from_drug_list,
+  median_drug_node_degree,
+  median_disease_node_degree,
+  
+  -- Calculate changes from previous release
+  n_nodes - lag(n_nodes) over (order by release_order) as nodes_change,
+  n_edges - lag(n_edges) over (order by release_order) as edges_change,
+  
+  -- Calculate percentage changes from previous release  
+  round(100.0 * (n_nodes - lag(n_nodes) over (order by release_order)) / lag(n_nodes) over (order by release_order), 2) as nodes_pct_change,
+  round(100.0 * (n_edges - lag(n_edges) over (order by release_order)) / lag(n_edges) over (order by release_order), 2) as edges_pct_change
+
+from 
+  all_release_metrics
+order by 
+  release_order`;
+
+    // Write the SQL file
+    const fs = require('fs');
+    const path = require('path');
+    
+    const sqlPath = path.join(__dirname, '..', 'sources', 'bq', 'release_trends.sql');
+    fs.writeFileSync(sqlPath, sql);
+    
+    console.log(`Generated release_trends.sql with ${validReleases.length} releases`);
+
+  } catch (error) {
+    console.error('Error generating SQL:', error);
+    process.exit(1);
+  }
+}
+
+// Run if called directly
+if (require.main === module) {
+  generateReleaseTrendsSQL();
+}
+
+module.exports = { generateReleaseTrendsSQL };


### PR DESCRIPTION
This adds a release trends page (I'm open to changing the title!) that shows stats on the number of nodes, edges, drug list entries and disease list entries over time, along with the number of primary knowledge sources in the graph over time.

To generate this, a node.js script iterates through bigquery tables to find all releases, and then produces a sql that is used to find and label counts over time. 