### PR TITLE
Nelson/ec 362 add arpa to gcs bucket access

### DIFF
--- a/infra/deployments/hub/dev/iam.tf
+++ b/infra/deployments/hub/dev/iam.tf
@@ -37,9 +37,8 @@ module "project_iam_bindings" {
     "roles/iam.serviceAccountTokenCreator" = local.tech_team_group
     "roles/storage.objectUser"             = local.tech_team_group
     "roles/storage.objectViewer"           = flatten([local.cross_account_sas, local.arpah_read_only_group])
-    "roles/storage.legacyBucketReader"     = local.arpah_read_only_group
     "roles/artifactregistry.writer"        = flatten([local.tech_team_group, [local.matrix_all_group]]) # enables people to run kedro experiment run
-    "roles/viewer"                         = flatten([local.matrix_viewers_group, local.cross_account_sas, local.custom_cloud_build_sa])
+    "roles/viewer"                         = flatten([local.matrix_viewers_group, local.cross_account_sas, local.custom_cloud_build_sa, local.arpah_read_only_group])
     "roles/bigquery.jobUser"               = flatten([local.matrix_viewers_group, local.cross_account_sas])
     # giving prod k8s cluster access to our dev data. 
     "roles/bigquery.dataViewer"       = flatten([local.matrix_viewers_group, local.cross_account_sas, local.prod_sas])


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request updates IAM role bindings in the `infra/deployments/hub/dev/iam.tf` file to grant the `arpah_read_only_group` additional access to resources. The main changes involve adding this group to relevant IAM roles to ensure appropriate permissions.

**IAM Role Binding Updates:**

* Added a new local variable `arpah_read_only_group` for the `arpah_read_only@everycure.org` group.
* Updated the `roles/storage.objectViewer` and `roles/viewer` IAM bindings to include the `arpah_read_only_group`, granting this group read-only access to storage objects and general viewer permissions.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
