### PR TITLE
feat: enhance Argo Workflows with memoization and caching support

### DIFF
--- a/infra/argo/applications/workflows/values.yaml
+++ b/infra/argo/applications/workflows/values.yaml
@@ -28,6 +28,10 @@ argo-workflows:
     # Schedule controller on management nodes
     nodeSelector:
       workload-type: management
+    
+    # Enable ConfigMap creation permissions for memoization and caching
+    rbac:
+      writeConfigMaps: true
 
     # Add billing labels to Argo Workflows controller pods
     podLabels:

--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -63,6 +63,14 @@ spec:
             counter:
               value: "1"
     name: kedro
+    memoize:
+      key: {% raw %}"{{inputs.parameters.kedro_nodes_cache_key}}"
+      {% endraw %}
+      maxAge: "72h"
+      cache:
+        configMap:
+          name: {% raw %}"{{workflow.parameters.mlflow_run_id}}"
+          {% endraw %}
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
@@ -106,7 +114,8 @@ spec:
         (
           lastRetry.message matches '.*pod deleted.*' ||
           lastRetry.message matches '.*imminent node shutdown.*' ||
-          lastRetry.message matches '.*node is draining.*'
+          lastRetry.message matches '.*node is draining.*' ||
+          lastRetry.message matches '.*pod was rejected.*'
         {# code 137 is for OOM. We are explicitly mention it so that in case of failure it is not retried #}
         ) && lastRetry.exitCode != 137
       backoff:
@@ -116,6 +125,7 @@ spec:
       parameters:
       - name: kedro_nodes
       - name: trimmed_kedro_nodes
+      - name: kedro_nodes_cache_key
       - name: num_gpus
       - name: memory_limit
       - name: memory_request
@@ -427,7 +437,9 @@ spec:
           - name: kedro_nodes
             value: {{ task.nodes }}
           - name: trimmed_kedro_nodes
-            value: {{ task.nodes[:63].replace(',', '-').rstrip('_-.') }}
+            value: {{task.nodes[:63].replace(',', '-').rstrip('_-.')}}
+          - name: kedro_nodes_cache_key
+            value: {{ (task.nodes.replace('_','').replace('-','').replace('.','').replace(',',''))[:63] }}
           - name: num_gpus
             value: {{ task.resources.num_gpus }}
           - name: memory_request


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request introduces improvements to Argo Workflows and the Kedro pipeline template, primarily adding memoization and caching capabilities for Kedro nodes, enhancing retry/resubmit logic, and updating resource parameter handling. The changes enable more efficient workflow execution by leveraging ConfigMap-based caching and improving pod retry conditions.

**Memoization and Caching Enhancements:**

* Added a `memoize` block to the Kedro step in `argo_wf_spec.tmpl`, enabling caching of Kedro node outputs using a cache key and a ConfigMap tied to the MLflow run ID, with a maximum cache age of 72 hours.
* Introduced a new parameter `kedro_nodes_cache_key` to the workflow spec and ensured it is passed to the Kedro step, with the value derived from a sanitized version of the Kedro nodes string. [[1]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R128) [[2]](diffhunk://#diff-4ed3b6ef2651099196cee6cda2edb1fc73b7e34bbd93fdff4b069d852cbb1c61R441-R442)

**RBAC and Controller Configuration:**

* Enabled the creation of ConfigMaps by setting `rbac.writeConfigMaps: true` in the Argo Workflows controller values, allowing memoization and caching to function.

**Retry Logic Improvements:**

* Updated the retry condition in the workflow template to include cases where the pod was rejected, in addition to existing node shutdown and draining scenarios.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- when submitting workflow, all nodes (that have been successful) run again, depending on the level of change.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
