### PR TITLE
Remove make install from pipelines/matrix's Makefile

### DIFF
--- a/.github/workflows/create-sample-release.yml
+++ b/.github/workflows/create-sample-release.yml
@@ -51,12 +51,14 @@ jobs:
         with:
           enable-cache: true
           version: "0.8.13"
+      
+      - name: Install Python dependencies
+        run: make install
 
-      - name: Install Argo & Python dependencies
+      - name: Install Argo dependencies
         working-directory: pipelines/matrix
         run: |
           make install_argo
-          make install
 
       - name: Authenticate with Google Cloud
         id: auth

--- a/.github/workflows/scheduled-sampling-pipeline.yml
+++ b/.github/workflows/scheduled-sampling-pipeline.yml
@@ -66,11 +66,13 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Argo & Python dependencies
+      - name: Install Python dependencies
+        run: make install
+
+      - name: Install Argo dependencies
         working-directory: pipelines/matrix
         run: |
           make install_argo
-          uv sync
 
       - name: Authenticate with Google Cloud for access_token
         id: auth

--- a/.github/workflows/submit-kedro-pipeline.yml
+++ b/.github/workflows/submit-kedro-pipeline.yml
@@ -56,11 +56,13 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install Python dependencies
+        run: make install
+
       - name: Install Argo & Python dependencies
         working-directory: pipelines/matrix
         run: |
           make install_argo
-          make install
 
       - name: Authenticate with Google Cloud
         id: auth

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,6 @@ format:
 
 install:
 	uv sync
+
+clean:
+	uv cache clean

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ make                    # run full integration test locally
 **Setup and Installation:**
 
 ```bash
-cd pipelines/matrix
 make install                   # Install dependencies with uv
+cd pipelines/matrix
 make fetch_secrets             # Fetch secrets from GCP Secret Manager
 ```
 

--- a/docs/src/getting_started/first_steps/local-setup.md
+++ b/docs/src/getting_started/first_steps/local-setup.md
@@ -15,7 +15,7 @@ As [mentioned earlier](./repo_structure.md#core-project-files), our codebase is 
 
 ### Virtual environment for python dependencies
 
-To execute the codebase, you need to set up a virtual environment for the python dependencies. This can be done by running the following command in the `pipelines/matrix` directory:
+To execute the codebase, you need to set up a virtual environment for the python dependencies. This can be done by running the following command in the root directory:
 
 ```bash
 make install

--- a/docs/src/references/common_errors.md
+++ b/docs/src/references/common_errors.md
@@ -57,7 +57,7 @@ You may encounter the following error during install:
 This issue can occur when local libraries in `libs/` have been updated but uv has cached an older version. Since uv manages the workspace dependencies automatically, cached versions can sometimes conflict with updates to local packages.
 
 **Solution**:
-Run this inside of `pipelines/matrix`
+Run this inside of the root directory
 ```bash
 rm -rf .venv/
 uv cache clean

--- a/infra/deployments/wg2/setup_vertex_workbench.sh
+++ b/infra/deployments/wg2/setup_vertex_workbench.sh
@@ -70,12 +70,11 @@ if [ ! -d "matrix" ]; then
     pushd ./
     export GIT_TOKEN=$(gcloud secrets versions access latest --secret=github-token --project=mtrx-wg2-modeling-dev-9yj)
     git clone https://${GIT_TOKEN}@github.com/everycure-org/matrix.git
+    make install
     cd matrix/pipelines/matrix
     # reset the remote to the normal URL, users are required to provide their own credentials to access the repo
     git remote set-url origin https://github.com/everycure-org/matrix.git
     make fetch_sa_key
-    make venv
-    make install
     # Install the virtual environment's Python as a Jupyter kernel without activating the venv
     .venv/bin/python -m ipykernel install --user --name matrix --display-name "Python (matrix)"
     # .venv/bin/jupyter kernelspec set-default matrix

--- a/pipelines/matrix/Makefile
+++ b/pipelines/matrix/Makefile
@@ -41,9 +41,6 @@ always:
 default: fetch_secrets install fast_test integration_test
 	echo "done!"
 
-install:
-	uv sync
-
 create_spark_dirs:
 	@echo "Creating local Spark temp directories..."
 	@mkdir -p data/local/{spark-temp,spark-warehouse,spark-checkpoints,java-tmp}

--- a/pipelines/matrix/README.md
+++ b/pipelines/matrix/README.md
@@ -25,18 +25,16 @@ brew link --overwrite openjdk@17
 
 1. Create Virtual Enviroment & Install Dependencies
 ```
+# From the root directory
 make install
 ```
-2. M
-TODO:
 
-
-Declare any dependencies in `requirements.in` for `pip` installation.
+Declare any dependencies in `pyproject.toml`
 
 To install them, run the following within your virtual environment (we recommend using [uv](https://docs.astral.sh/uv/) & Python 3.11):
 
 ```
-uv pip install -r requirements.txt
+make install
 ```
 
 
@@ -58,23 +56,17 @@ pytest
 
 To configure the coverage threshold, look at the `.coveragerc` file.
 
-## Project dependencies
-
-To see and update the dependency requirements for your project use `requirements.txt`. Install the project requirements with `pip install -r requirements.txt`.
-
-[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
-
 ## How to work with Kedro and notebooks
 
 > Note: Using `kedro jupyter` or `kedro ipython` to run your notebook provides these variables in scope: `catalog`, `context`, `pipelines` and `session`.
 >
-> Jupyter, JupyterLab, and IPython are already included in the project requirements by default, so once you have run `pip install -r requirements.txt` you will not need to take any extra steps before you use them.
+> Jupyter, JupyterLab, and IPython are already included in the project requirements by default, so once you have run `make install` you will not need to take any extra steps before you use them.
 
 ### Jupyter
 To use Jupyter notebooks in your Kedro project, you need to install Jupyter:
 
 ```
-pip install jupyter
+uv pip install jupyter
 ```
 
 After installing Jupyter, you can start a local notebook server:
@@ -87,7 +79,7 @@ kedro jupyter notebook
 To use JupyterLab, you need to install it:
 
 ```
-pip install jupyterlab
+uv pip install jupyterlab
 ```
 
 You can also start JupyterLab:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Running `make install` in the `pipelines/matrix` directory causes conflicts with the root `make install`. 

In this PR I remove it from `pipelines/matrix` Makefile, and refactored the Github actions and documentation to reflect it.

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
