### PR TITLE
Fix Google Sheet to get worksheet by gid

### DIFF
--- a/libs/matrix-gcp-datasets/src/matrix_gcp_datasets/gcp.py
+++ b/libs/matrix-gcp-datasets/src/matrix_gcp_datasets/gcp.py
@@ -251,7 +251,7 @@ class GoogleSheetsDataset(CSVDataset):
             service_account_file_path: Path to the service account file. The Google Sheet must be shared with this service account's email.
         """
         self._gc = gspread.service_account(filename=service_account_file_path)
-        self._worksheet = self._gc.open_by_url(spreadsheet_url).get_worksheet(worksheet_gid)
+        self._worksheet = self._gc.open_by_url(spreadsheet_url).get_worksheet_by_id(worksheet_gid)
 
         super().__init__(filepath=None)
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

I forgot to change the function to get the spreadsheet's worksheet in the previous PR. It still gets it by index and not using the `gid`.

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
