### PR TITLE
union normalization summary tables

### DIFF
--- a/pipelines/matrix/conf/cloud/integration/catalog.yml
+++ b/pipelines/matrix/conf/cloud/integration/catalog.yml
@@ -52,3 +52,8 @@ integration.int.{source}.normalization_summary:
   <<: *_bigquery_ds
   filepath: ${globals:paths.integration}/int/{source}/normalization_summary
   table: "{source}_normalization_summary"
+
+integration.prm.unified_normalization_summary:
+  <<: *_bigquery_ds
+  filepath: ${globals:paths.integration}/prm/unified_normalization_summary
+  table: "unified_normalization_summary"

--- a/pipelines/matrix/src/matrix/pipelines/integration/pipeline.py
+++ b/pipelines/matrix/src/matrix/pipelines/integration/pipeline.py
@@ -153,7 +153,7 @@ def create_pipeline(**kwargs) -> Pipeline:
                     func=nodes.create_core_id_mapping,
                     inputs=[
                         *[
-                            f'integration.int.{source["name"]}.nodes.norm@spark'
+                            f"integration.int.{source['name']}.nodes.norm@spark"
                             for source in settings.DYNAMIC_PIPELINES_MAPPING().get("integration")
                             if source.get("is_core", False)
                         ]
@@ -167,7 +167,7 @@ def create_pipeline(**kwargs) -> Pipeline:
                         "params:integration.deduplication.retrieve_most_specific_category",
                         "integration.int.core_node_mapping",
                         *[
-                            f'integration.int.{source["name"]}.nodes.norm@spark'
+                            f"integration.int.{source['name']}.nodes.norm@spark"
                             for source in settings.DYNAMIC_PIPELINES_MAPPING().get("integration")
                             if source.get("integrate_in_kg", True)
                         ],
@@ -179,7 +179,7 @@ def create_pipeline(**kwargs) -> Pipeline:
                     func=nodes.unify_ground_truth,
                     inputs=[
                         *[
-                            f'integration.int.{source["name"]}.edges.norm@spark'
+                            f"integration.int.{source['name']}.edges.norm@spark"
                             for source in settings.DYNAMIC_PIPELINES_MAPPING().get("integration")
                             if "ground_truth" in source["name"]
                         ],
@@ -192,7 +192,7 @@ def create_pipeline(**kwargs) -> Pipeline:
                     inputs=[
                         "integration.int.core_node_mapping",
                         *[
-                            f'integration.int.{source["name"]}.edges.norm@spark'
+                            f"integration.int.{source['name']}.edges.norm@spark"
                             for source in settings.DYNAMIC_PIPELINES_MAPPING().get("integration")
                             if source.get("integrate_in_kg", True)
                         ],
@@ -200,6 +200,18 @@ def create_pipeline(**kwargs) -> Pipeline:
                     outputs="integration.prm.unified_edges",
                     name="create_prm_unified_edges",
                     argo_config=ArgoResourceConfig(memory_request=72, memory_limit=72),
+                ),
+                node(
+                    func=nodes._union_datasets,  # Reuse your existing union function
+                    inputs=[
+                        *[
+                            f"integration.int.{source['name']}.normalization_summary"
+                            for source in settings.DYNAMIC_PIPELINES_MApwdPPING().get("integration")
+                            # if source.get("has_edges", True)  # Only sources that have normalization summaries
+                        ]
+                    ],
+                    outputs="integration.prm.unified_normalization_summary",
+                    name="create_unified_normalization_summary",
                 ),
                 node(
                     func=nodes.check_nodes_and_edges_matching,


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

Added a new node to the integration pipeline that combines all normalization summary outputs from individual sources into a single unified table. This enables comprehensive analysis of normalization results across all data sources in one place.
The change leverages the existing _union_datasets function to union all normalization_summary outputs while preserving the upstream_data_source column that identifies which source each row originated from.


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- https://linear.app/everycure/issue/XDATA-238/simplify-normalized-table-for-kg-dashboard

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
