### PR TITLE
Fix regex patterns for pod rejection messages in workflow spec

### DIFF
--- a/pipelines/matrix/templates/argo_wf_spec.tmpl
+++ b/pipelines/matrix/templates/argo_wf_spec.tmpl
@@ -111,8 +111,8 @@ spec:
           lastRetry.message matches '.*pod deleted.*' ||
           lastRetry.message matches '.*imminent node shutdown.*' ||
           lastRetry.message matches '.*node is draining.*' ||
-          lastRetry.message matches '*Pod was rejected*' ||
-          lastRetry.message matches '*Pod was rejected as the node is shutting down*'
+          lastRetry.message matches '.*Pod was rejected.*' ||
+          lastRetry.message matches '.*node is shutting down.*'
         {# code 137 is for OOM. We are explicitly mention it so that in case of failure it is not retried #}
         ) && lastRetry.exitCode != 137
       backoff:


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request makes a minor update to the retry conditions in the `argo_wf_spec.tmpl` template. The change refines the pattern matching for pod rejection and node shutdown messages to improve workflow reliability.

* Retry logic: Updated the message matching patterns to use regular expressions for pod rejection and node shutdown scenarios, ensuring more robust detection of these conditions in `argo_wf_spec.tmpl`.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
