### PR TITLE
feat: add gpt4-mini and haiku models

### DIFF
--- a/infra/argo/app-of-apps/templates/litellm.yaml
+++ b/infra/argo/app-of-apps/templates/litellm.yaml
@@ -60,6 +60,29 @@ spec:
                 api_key: os.environ/ANTHROPIC_API_KEY
               model_info:
                 cache: true
+
+            - model_name: gpt-4o-mini
+              litellm_params:
+                model: openai/gpt-4o-mini
+                api_key: os.environ/OPENAI_API_KEY
+              model_info:
+                cache: true
+            - model_name: text-embedding-3-large
+              litellm_params:
+                model: openai/text-embedding-3-large
+                api_key: os.environ/OPENAI_API_KEY
+            - model_name: text-embedding-3-small
+              litellm_params:
+                model: openai/text-embedding-3-small
+                api_key: os.environ/OPENAI_API_KEY
+            - model_name: claude-3-5-haiku
+              litellm_params:
+                model: anthropic/claude-3-5-haiku-20241022
+                api_key: os.environ/ANTHROPIC_API_KEY
+            - model_name: claude-3-haiku
+              litellm_params:
+                model: anthropic/claude-3-haiku-20240307
+                api_key: os.environ/ANTHROPIC_API_KEY
           router_settings:
             # Redis for cross-pod RPM/TPM + routing state
             redis_host: redis.redis.svc.cluster.local


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `gpt-4o-mini`, OpenAI embeddings (`text-embedding-3-large|small`), and Anthropic `claude-3-5-haiku`/`claude-3-haiku` to the litellm model list, with cache enabled for `gpt-4o-mini`.
> 
> - **Infra — litellm config (`infra/argo/app-of-apps/templates/litellm.yaml`)**:
>   - **Model additions**:
>     - OpenAI: `gpt-4o-mini` (cached), `text-embedding-3-large`, `text-embedding-3-small`.
>     - Anthropic: `claude-3-5-haiku` (`anthropic/claude-3-5-haiku-20241022`), `claude-3-haiku` (`anthropic/claude-3-haiku-20240307`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24d8f1d47efe84d75d8bb988e81769c7dde2c858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->