### PR TITLE
Bump drug list version to v0.1.4

### DIFF
--- a/pipelines/matrix/conf/base/globals.yml
+++ b/pipelines/matrix/conf/base/globals.yml
@@ -49,7 +49,7 @@ data_sources:
     version: 20230309 # NOTE: Here 0309 is a period of time (here Mar to Sep 2023)
   drug_list:
     # check releases here: https://github.com/everycure-org/core-entities/releases
-    version: v0.1.1
+    version: v0.1.4
   disease_list:
     # check releases here: https://github.com/everycure-org/core-entities/releases
     version: v0.1.3


### PR DESCRIPTION
The new drug list is required because of the new version of the Node Normalizer would make the pipeline fail otherwise.

It however will induce ID drift in upcoming releases until we migrate to our EC drug id 

# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
