### PR TITLE
feat: Update model parameters and cache control for OpenAI models in litellm configuration

### DIFF
--- a/infra/argo/app-of-apps/templates/litellm.yaml
+++ b/infra/argo/app-of-apps/templates/litellm.yaml
@@ -44,45 +44,106 @@ spec:
           general_settings:
             telemetry: false
           model_list:
+            # OpenAI
+            - model_name: gpt-5
+              litellm_params:
+                model: openai/gpt-5
+                api_key: os.environ/OPENAI_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
+            - model_name: gpt-5-2025-08-07
+              litellm_params:
+                model: openai/gpt-5-2025-08-07
+                api_key: os.environ/OPENAI_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
+            - model_name: gpt-5-mini
+              litellm_params:
+                model: openai/gpt-5-mini
+                api_key: os.environ/OPENAI_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
+            - model_name: gpt-5-mini-2025-08-07
+              litellm_params:
+                model: openai/gpt-5-mini-2025-08-07
+                api_key: os.environ/OPENAI_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
+            - model_name: gpt-5-nano
+              litellm_params:
+                model: openai/gpt-5-nano
+                api_key: os.environ/OPENAI_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
+            - model_name: gpt-5-nano-2025-08-07
+              litellm_params:
+                model: openai/gpt-5-nano-2025-08-07
+                api_key: os.environ/OPENAI_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
             - model_name: gpt-4o
               litellm_params:
                 model: openai/gpt-4o
                 api_key: os.environ/OPENAI_API_KEY
-              model_info:
-                cache: true
+                cache_control_injection_points:
+                  - location: message
+                    role: user
             - model_name: claude-3-5-sonnet
               litellm_params:
                 model: anthropic/claude-3-5-sonnet-20240620
                 api_key: os.environ/ANTHROPIC_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
             - model_name: claude-4-sonnet-20250514
               litellm_params:
                 model: anthropic/claude-4-sonnet-20250514
                 api_key: os.environ/ANTHROPIC_API_KEY
-              model_info:
-                cache: true
-
+                cache_control_injection_points:
+                  - location: message
+                    role: user
             - model_name: gpt-4o-mini
               litellm_params:
                 model: openai/gpt-4o-mini
                 api_key: os.environ/OPENAI_API_KEY
-              model_info:
-                cache: true
+                cache_control_injection_points:
+                  - location: message
+                    role: user
             - model_name: text-embedding-3-large
               litellm_params:
                 model: openai/text-embedding-3-large
                 api_key: os.environ/OPENAI_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
             - model_name: text-embedding-3-small
               litellm_params:
                 model: openai/text-embedding-3-small
                 api_key: os.environ/OPENAI_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
+            # OpenAI
             - model_name: claude-3-5-haiku
               litellm_params:
                 model: anthropic/claude-3-5-haiku-20241022
                 api_key: os.environ/ANTHROPIC_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
             - model_name: claude-3-haiku
               litellm_params:
                 model: anthropic/claude-3-haiku-20240307
                 api_key: os.environ/ANTHROPIC_API_KEY
+                cache_control_injection_points:
+                  - location: message
+                    role: user
           router_settings:
             # Redis for cross-pod RPM/TPM + routing state
             redis_host: redis.redis.svc.cluster.local
@@ -90,6 +151,7 @@ spec:
             # redis_password: os.environ/REDIS_PASSWORD
             num_retries: 2
           litellm_settings:
+            set_verbose: true
             cache: true
             cache_params:
               type: redis
@@ -97,8 +159,6 @@ spec:
               port: 6379
               # password: os.environ/REDIS_PASSWORD   
               ttl: 86400  # Cache for 1 day
-              namespace: "litellm_cache"
-              redis_flush_size: 100
           ui:
             enabled: true
         masterkeySecretName: litellm-master-key


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request updates the `litellm.yaml` configuration to add support for new OpenAI GPT-5 models and standardises cache control settings across all model entries. It also enables verbose logging and makes minor adjustments to the cache configuration.

**Model configuration updates:**

* Added new OpenAI GPT-5 models (`gpt-5`, `gpt-5-2025-08-07`, `gpt-5-mini`, `gpt-5-mini-2025-08-07`, `gpt-5-nano`, `gpt-5-nano-2025-08-07`) to the `model_list`, each with appropriate `litellm_params` and cache control injection points.
* Standardized `cache_control_injection_points` for all models, including existing OpenAI and Anthropic models, to ensure consistent cache behaviour.

**Cache and logging configuration:**

* Enabled verbose logging by setting `set_verbose: true` under `litellm_settings`.
* Removed unused or redundant cache parameters (`namespace` and `redis_flush_size`) from the cache configuration.

# Checklist:

<!-- Please remove any items from this checklist that do not apply to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on GitHub to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our Slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
