### PR TITLE
feat: Add supported call types for Redis cache configuration in litellm

### DIFF
--- a/infra/argo/app-of-apps/templates/litellm.yaml
+++ b/infra/argo/app-of-apps/templates/litellm.yaml
@@ -159,6 +159,7 @@ spec:
               port: 6379
               # password: os.environ/REDIS_PASSWORD
               ttl: 2592000  # Cache for 30 days
+              supported_call_types: ['completion', 'acompletion', 'embedding', 'aembedding', 'atranscription', 'transcription', 'atext_completion', 'text_completion', 'arerank', 'rerank', 'responses']
           ui:
             enabled: true
         masterkeySecretName: litellm-master-key


### PR DESCRIPTION
# Working Screenshot

<img width="1791" height="1155" alt="image" src="https://github.com/user-attachments/assets/2f268f36-5339-41d9-a9d3-65b87c58562d" />

# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request makes a small configuration update to the `litellm.yaml` file, expanding the list of supported call types for the cache specification. This ensures the system can handle a wider variety of request types.

* Added new supported call types to the `supported_call_types` list in the cache configuration, including `'completion'`, `'acompletion'`, `'embedding'`, `'aembedding'`, `'atranscription'`, `'transcription'`, `'atext_completion'`, `'text_completion'`, `'arerank'`, `'rerank'`, and `'responses'`.
* Almost all of the above calls were default calls. The only addition is: `responses`


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- `responses` API response is not being cached.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
