### PR TITLE
Add IAM member resource for Service Account User role in workbench configuration

### DIFF
--- a/infra/deployments/wg2/modules/workbench/main.tf
+++ b/infra/deployments/wg2/modules/workbench/main.tf
@@ -64,3 +64,11 @@ resource "google_workbench_instance" "user_workbench" {
     email               = local.sanitized_email
   }, var.labels)
 }
+
+# Grant the user Service Account User role on the workbench service account
+# This allows the user to use the service account when creating/accessing the workbench
+resource "google_service_account_iam_member" "workbench_user_sa_access" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.service_account}"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "user:${var.email}"
+}


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request adds a new IAM binding to the Workbench deployment module, ensuring that the specified user is granted permission to use the Workbench service account. This is necessary for the user to create or access the Workbench instance using that service account if they have an external domain (other than the Everycure domain)

**IAM permissions update:**

* Added a `google_service_account_iam_member` resource to grant the `roles/iam.serviceAccountUser` role to the user on the Workbench service account, enabling the user to act as the service account when interacting with the Workbench.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->

```bash

* Failed to execute "terraform apply -auto-approve -input=false plan.tfplan" in .
--
  | ╷
  | │ Error: Error creating Instance: googleapi: Error 403: jonathan.farag@arpa-h.gov needs iam.serviceAccounts.ActAs (Service Account User) permission on VM Service Account projects/mtrx-wg2-modeling-dev-9yj/serviceAccounts/vertex-ai-workbench-sa@mtrx-wg2-modeling-dev-9yj.iam.gserviceaccount.com, permission denied
  | │
  | │   with module.workbenches["jonathan"].google_workbench_instance.user_workbench,
  | │   on modules/workbench/main.tf line 8, in resource "google_workbench_instance" "user_workbench":
  | │    8: resource "google_workbench_instance" "user_workbench" {
  | │
  | ╵
```


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
