### PR TITLE
Add Py4J gateway startup timeout to Spark configuration

### DIFF
--- a/pipelines/matrix/conf/base/spark.yml
+++ b/pipelines/matrix/conf/base/spark.yml
@@ -35,3 +35,5 @@ spark.sql.adaptive.coalescePartitions.minPartitionSize: 16MB
 spark.jars: gcs-connector-hadoop3-2.2.2-shaded.jar
 spark.jars.packages: com.google.cloud.spark:spark-3.5-bigquery:0.39.0,org.neo4j:neo4j-connector-apache-spark_2.12:5.3.0_for_spark_3,org.xerial:sqlite-jdbc:3.47.0.0
 spark.hadoop.fs.gs.impl: com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem
+# Increase Py4J gateway startup timeout to prevent connection issues
+spark.driver.extraJavaOptions: -Dpy4j.gateway.startup.timeout=30000


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request makes a minor configuration update to the Spark setup to improve reliability during startup.

* Configuration improvement:
  * Increased the Py4J gateway startup timeout to 30 seconds by adding `spark.driver.extraJavaOptions: -Dpy4j.gateway.startup.timeout=30000` in `pipelines/matrix/conf/base/spark.yml`. This helps prevent connection issues when starting the Py4J gateway.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- PySparkRuntimeError: [JAVA_GATEWAY_EXITED] Java gateway process exited before 
sending its port number.


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
