### PR TITLE
Disable spot instances for non-dev environments and conditionally include spot node pools

### DIFF
--- a/infra/modules/stacks/compute_cluster/gke.tf
+++ b/infra/modules/stacks/compute_cluster/gke.tf
@@ -69,7 +69,7 @@ locals {
     enable_gcfs        = true
     enable_gvnic       = true
     initial_node_count = 0
-    spot               = false
+    spot               = true
     }
   ]
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request updates the configuration for GKE node pools in the `infra/modules/stacks/compute_cluster/gke.tf` file, primarily to adjust how spot node pools are managed and to refine their usage based on the deployment environment.

Environment-based logic:

* The inclusion of spot node pools (`n2d_spot_node_pools` and `gpu_spot_node_pools`) is now conditional, so they are only added when the environment is set to `"dev"`. In other environments, these spot pools are omitted.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- Retry failed for spot instance reclaim


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on GitHub to make sure no unwanted files have been committed. 

<!-- uncomment the below section if you want a notice to be sent to our Slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
