### PR TITLE
Hotfix: use correct variable for PKS markdown generation

### DIFF
--- a/pipelines/matrix/src/matrix/pipelines/document_kg/nodes.py
+++ b/pipelines/matrix/src/matrix/pipelines/document_kg/nodes.py
@@ -281,7 +281,5 @@ def create_pks_documentation(matrix_subset_relevant_sources: Dict[str, Any], tem
     """Generate markdown documentation for PKS used in the matrix."""
     pks_documentation_texts = _generate_list_of_pks_markdown_strings(matrix_subset_relevant_sources, template=templates)
     overview_table = _generate_overview_table_of_pks_markdown(matrix_subset_relevant_sources, template=templates)
-    documentation_md = _generate_pks_markdown_documentation(
-        matrix_subset_relevant_sources, overview_table, template=templates
-    )
+    documentation_md = _generate_pks_markdown_documentation(pks_documentation_texts, overview_table, template=templates)
     return documentation_md


### PR DESCRIPTION
# Description of the changes <!-- required! -->

When optimizing the code for #1846, I accidentally used the wrong variable for markdown generation which leads to the loop not being executed. FIxing 

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
