### PR TITLE
Remove Spot Instances in both dev and Prod

### DIFF
--- a/infra/modules/stacks/compute_cluster/gke.tf
+++ b/infra/modules/stacks/compute_cluster/gke.tf
@@ -117,6 +117,9 @@ locals {
     local.n2d_node_pools,
     local.gpu_node_pools,
     local.management_node_pools,
+    # Disable spot node pools for now.
+    # var.environment == "dev" ? local.n2d_spot_node_pools : [],
+    # var.environment == "dev" ? local.gpu_spot_node_pools : [],
     local.github_runner_node_pools
   )
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request makes a minor update to the node pool configuration logic in the `infra/modules/stacks/compute_cluster/gke.tf` file. The change removes the conditional addition of spot node pools for the "dev" environment, simplifying the local node pool aggregation.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that do not apply to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
