### PR TITLE
Add GitHub Actions service account for read access to dev bucket

### DIFF
--- a/infra/deployments/hub/prod/iam.tf
+++ b/infra/deployments/hub/prod/iam.tf
@@ -90,3 +90,11 @@ resource "google_project_iam_member" "bigquery_read_from_orchard_prod" {
   role    = google_project_iam_custom_role.bigquery_read_from_orchard_prod.id
   member  = local.prod_k8s_sas
 }
+
+// Granting read access to the dev bucket for prod service accounts.
+resource "google_storage_bucket_iam_member" "github_actions_rw_dev_bucket_access_to_prod_read_only" {
+  for_each = toset(local.binding_members)
+  bucket   = var.storage_bucket_name
+  role     = "roles/storage.objectViewer"
+  member   = local.matrix_hub_dev_github_sa_rw_member
+}

--- a/infra/deployments/hub/prod/locals.tf
+++ b/infra/deployments/hub/prod/locals.tf
@@ -1,11 +1,13 @@
 locals {
   # Base paths
-  embiology_path_raw      = "data/01_RAW/embiology"
-  embiology_path          = "projects/_/buckets/${var.storage_bucket_name}/objects/${local.embiology_path_raw}/"
-  dev_bucket_name         = "mtrx-us-central1-hub-dev-storage"
-  orchard_dev_project_id  = "ec-orchard-dev"
-  orchard_prod_project_id = "ec-orchard-prod"
-  prod_k8s_sas            = "serviceAccount:sa-k8s-node@mtrx-hub-prod-sms.iam.gserviceaccount.com" # Kubernetes node SA for cluster workloads
+  embiology_path_raw                 = "data/01_RAW/embiology"
+  embiology_path                     = "projects/_/buckets/${var.storage_bucket_name}/objects/${local.embiology_path_raw}/"
+  dev_bucket_name                    = "mtrx-us-central1-hub-dev-storage"
+  orchard_dev_project_id             = "ec-orchard-dev"
+  orchard_prod_project_id            = "ec-orchard-prod"
+  prod_k8s_sas                       = "serviceAccount:sa-k8s-node@mtrx-hub-prod-sms.iam.gserviceaccount.com"         # Kubernetes node SA for cluster workloads
+  matrix_hub_dev_github_sa_rw_member = "serviceAccount:sa-github-actions-rw@mtrx-hub-dev-3of.iam.gserviceaccount.com" # GitHub Actions RW SA for dev
+
 
   # Allowed path prefixes for access
   allowed_paths = [


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

This pull request introduces changes to the production IAM configuration for the Hub deployment, primarily to grant read-only access to the production storage bucket for Github Dev service accounts. This improves cross-environment access management and enables development workflows to read objects from the development bucket when necessary.

**Access control updates:**

* Added a new `google_storage_bucket_iam_member` resource to grant the dev GitHub Actions service account read-only (`roles/storage.objectViewer`) access to the production storage bucket.
* Defined a new local variable `matrix_hub_dev_github_sa_rw_member` representing the GitHub Actions read-write service account for the development environment, used in the IAM binding above.

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
