### PR TITLE
fixing HPO mappings

### DIFF
--- a/apps/matrix-cli/src/matrix_cli/io/primekg.py
+++ b/apps/matrix-cli/src/matrix_cli/io/primekg.py
@@ -187,10 +187,24 @@ def build_nodes(
         )
         .with_columns(
             [
-                pl.when(pl.col("node_source").str.contains("HPO|MONDO|UBERON"))
+                pl.when(pl.col("node_source").str.contains("MONDO|UBERON"))
                 .then(
                     pl.concat_str(
                         [pl.col("node_source"), pl.col("node_id").cast(pl.Utf8).str.pad_start(7, "0")],
+                        separator=":",
+                        ignore_nulls=True,
+                    )
+                )
+                .otherwise(pl.col("node_source"))
+                .alias("node_source"),
+            ]
+        )
+        .with_columns(
+            [
+                pl.when(pl.col("node_source").str.contains("HPO"))
+                .then(
+                    pl.concat_str(
+                        [pl.lit("HP"), pl.col("node_id").cast(pl.Utf8).str.pad_start(7, "0")],
                         separator=":",
                         ignore_nulls=True,
                     )

--- a/libs/matrix-io-utils/src/matrix_io_utils/primekg.py
+++ b/libs/matrix-io-utils/src/matrix_io_utils/primekg.py
@@ -69,10 +69,24 @@ def fix_curies(edges: pl.LazyFrame) -> pl.LazyFrame:
             )
             .with_columns(
                 [
-                    pl.when(pl.col(map_item["source"]).str.contains("HPO|MONDO|UBERON"))
+                    pl.when(pl.col(map_item["source"]).str.contains("MONDO|UBERON"))
                     .then(
                         pl.concat_str(
                             [pl.col(map_item["source"]), pl.col(map_item["id"]).cast(pl.Utf8).str.pad_start(7, "0")],
+                            separator=":",
+                            ignore_nulls=True,
+                        )
+                    )
+                    .otherwise(pl.col(map_item["sub_or_obj_col"]))
+                    .alias(map_item["sub_or_obj_col"]),
+                ]
+            )
+            .with_columns(
+                [
+                    pl.when(pl.col(map_item["source"]).str.contains("HPO"))
+                    .then(
+                        pl.concat_str(
+                            [pl.lit("HP"), pl.col(map_item["id"]).cast(pl.Utf8).str.pad_start(7, "0")],
                             separator=":",
                             ignore_nulls=True,
                         )

--- a/pipelines/matrix/src/matrix/pipelines/preprocessing/nodes.py
+++ b/pipelines/matrix/src/matrix/pipelines/preprocessing/nodes.py
@@ -68,10 +68,24 @@ def primekg_build_nodes(
         )
         .with_columns(
             [
-                pl.when(pl.col("node_source").str.contains("HPO|MONDO|UBERON"))
+                pl.when(pl.col("node_source").str.contains("MONDO|UBERON"))
                 .then(
                     pl.concat_str(
                         [pl.col("node_source"), pl.col("node_id").cast(pl.Utf8).str.pad_start(7, "0")],
+                        separator=":",
+                        ignore_nulls=True,
+                    )
+                )
+                .otherwise(pl.col("node_source"))
+                .alias("node_source"),
+            ]
+        )
+        .with_columns(
+            [
+                pl.when(pl.col("node_source").str.contains("HPO"))
+                .then(
+                    pl.concat_str(
+                        [pl.col("HP"), pl.col("node_id").cast(pl.Utf8).str.pad_start(7, "0")],
                         separator=":",
                         ignore_nulls=True,
                     )


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Fixing instances where HPO was the CURIE prefix....should be HP instead.


## Fixes / Resolves the following issues:
-  https://linear.app/everycure/issue/XDATA-264/fix-hpo-node-prefix-in-primekg-pre-processing


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
