### PR TITLE
Remove two redundant logging.basicConfig calls

### DIFF
--- a/libs/matrix-fabricator/src/matrix_fabricator/fabrication.py
+++ b/libs/matrix-fabricator/src/matrix_fabricator/fabrication.py
@@ -60,7 +60,6 @@ from faker import Faker
 from pandas.api.types import is_list_like
 
 # --- Configuration ---
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 # Default path for loading functions if namespace isn't specified

--- a/pipelines/matrix/src/matrix/pipelines/document_kg/nodes.py
+++ b/pipelines/matrix/src/matrix/pipelines/document_kg/nodes.py
@@ -7,7 +7,6 @@ import pyspark.sql.functions as F
 from jinja2 import Template
 from matrix_inject.inject import inject_object
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Deleted redundant logging.basicConfig initializations from fabrication.py and nodes.py to prevent multiple logger configurations and potential log formatting issues.

# Description of the changes <!-- required! -->

In discussion with @JacquesVergine we determined this to be redundant - logger output formatting should not be determined on a per-pipeline level but be the same for the whole stack

## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [X] Added label to PR (e.g. `enhancement` or `bug`)
- [X] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [X] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] ~Made corresponding changes to the documentation~
- [ ] ~Added tests that prove my fix is effective or that my feature works~
- [ ] ~Any dependent changes have been merged and published in downstream modules~

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
