### PR TITLE
Revert evaluation suite to translator_id

### DIFF
--- a/pipelines/matrix/tests/pipelines/test_matrix_generation.py
+++ b/pipelines/matrix/tests/pipelines/test_matrix_generation.py
@@ -120,10 +120,10 @@ def sample_graph(sample_node_embeddings):
 def sample_matrix_data():
     return pd.DataFrame(
         [
-            {"source": "ec_drug_1", "source_curie": "drug_1", "target": "disease_1"},
-            {"source": "ec_drug_2", "source_curie": "drug_2", "target": "disease_1"},
-            {"source": "ec_drug_1", "source_curie": "drug_1", "target": "disease_2"},
-            {"source": "ec_drug_2", "source_curie": "drug_2", "target": "disease_2"},
+            {"ec_drug_id": "ec_drug_1", "source": "drug_1", "target": "disease_1"},
+            {"ec_drug_id": "ec_drug_2", "source": "drug_2", "target": "disease_1"},
+            {"ec_drug_id": "ec_drug_1", "source": "drug_1", "target": "disease_2"},
+            {"ec_drug_id": "ec_drug_2", "source": "drug_2", "target": "disease_2"},
         ]
     )
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

Reverts [this PR](https://github.com/everycure-org/matrix/pull/1949)'s code changes related to the matrix_generation nodes and its tests.


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
