### PR TITLE
Enhance Neo4j CronJob to use rollout restart and improve error

### DIFF
--- a/infra/argo/applications/neo4j/templates/certificate-refresh-cronjob.yaml
+++ b/infra/argo/applications/neo4j/templates/certificate-refresh-cronjob.yaml
@@ -29,8 +29,17 @@ spec:
             - -c
             - |
               echo "Restarting Neo4j to refresh certificates at $(date)"
-              kubectl exec -n {{ .Release.Namespace }} {{ .Release.Name }}-0 -- neo4j restart
-              echo "Neo4j restart completed at $(date)"
+              kubectl rollout restart statefulset/{{ .Release.Name }} -n {{ .Release.Namespace }}
+              
+              # Wait for rollout to complete (timeout after 10 minutes)
+              kubectl rollout status statefulset/{{ .Release.Name }} -n {{ .Release.Namespace }} --timeout=10m
+              
+              if [ $? -eq 0 ]; then
+                echo "Neo4j StatefulSet restart completed successfully at $(date)"
+              else
+                echo "ERROR: Neo4j StatefulSet restart failed or timed out at $(date)"
+                exit 1
+              fi
           restartPolicy: OnFailure
 ---
 # Service account for the CronJob
@@ -40,16 +49,19 @@ metadata:
   name: {{ .Release.Name }}-sa
   namespace: {{ .Release.Namespace }}
 ---
-# Role with permissions to exec into pods
+# Role with permissions to restart StatefulSets
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-pod-exec-role
   namespace: {{ .Release.Namespace }}
 rules:
-- apiGroups: [""]
-  resources: ["pods", "pods/exec"]
-  verbs: ["get", "list", "create"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets"]
+  verbs: ["get", "list", "patch"]
+- apiGroups: ["apps"]
+  resources: ["statefulsets/status"]
+  verbs: ["get"]
 ---
 # RoleBinding to link the service account to the role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/infra/argo/applications/neo4j/values.yaml
+++ b/infra/argo/applications/neo4j/values.yaml
@@ -2,6 +2,9 @@ neo4j: # the name of the helm dependency
   # see https://github.com/neo4j/helm-charts/issues/313
   # and https://github.com/neo4j/helm-charts/blob/f19b4f9f18e99442bfdd50a2e67a779d7b56ff3d/neo4j/values.yaml#L11
   disableLookups: true
+  # Reduce termination grace period from 1 hour to 10 minutes for faster restarts
+  # This is acceptable since we have regular backups and Neo4j can recover from graceful shutdowns
+  terminationGracePeriodSeconds: 600
   podSpec:
     # Force replacement of StatefulSet to update nodeSelector/tolerations
     annotations:


### PR DESCRIPTION
Enhance Neo4j CronJob to use rollout restart and improve error and update termination grace period for faster restarts

# Description of the changes <!-- required! -->

This pull request updates the Neo4j certificate refresh process to improve reliability and speed of restarts. The main changes include switching from pod-level restarts to StatefulSet-level rollouts, updating RBAC permissions to match this new approach, and reducing the termination grace period to enable faster restarts.

**Certificate refresh and restart process improvements:**

* The certificate refresh CronJob script now restarts Neo4j by triggering a StatefulSet rollout (`kubectl rollout restart statefulset/...`) instead of directly executing a restart inside the pod. It also waits for the rollout to complete and provides error handling if the rollout fails or times out.

**RBAC and permissions updates:**

* The Role definition now grants permissions to restart and monitor StatefulSets rather than exec into pods, updating the allowed resources and verbs accordingly.

**Operational configuration changes:**

* The Neo4j Helm values now set `terminationGracePeriodSeconds` to 600 seconds (10 minutes) instead of the default 1 hour, allowing for faster restarts while maintaining data safety due to regular backups.

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
