### PR TITLE
Fix GraphFrame SparkSession "Race Condition" in Parallel Kedro Execution

### DIFF
--- a/pipelines/matrix/src/matrix/pipelines/integration/connectivity_metrics.py
+++ b/pipelines/matrix/src/matrix/pipelines/integration/connectivity_metrics.py
@@ -69,11 +69,15 @@ def compute_connected_components_graphframes(nodes: ps.DataFrame, edges: ps.Data
         - "component_stats": DataFrame with (component_id, component_size, num_components) - statistics
     """
     from graphframes import GraphFrame
+    from pyspark.sql import SparkSession
 
     logger.info("Computing connected components using GraphFrames...")
 
     # Ensure SparkSession is active in this thread (needed for GraphFrame)
     # GraphFrame relies on SparkSession.getActiveSession() which may return None in parallel threads
+    if SparkSession.getActiveSession() is None:
+        SparkSession.builder.getOrCreate()
+
     gf_nodes = nodes.select(F.col("id"))
 
     # Prepare edges for GraphFrame (needs 'src' and 'dst' columns)


### PR DESCRIPTION
# Description of the changes <!-- required! -->

## The Problem: GraphFrame SparkSession "Race Condition" (not really) in Parallel Kedro Execution

When running the Kedro pipeline with `ThreadRunner` (parallel execution), the `compute_connected_components` node intermittently fails with:

```
AttributeError: 'NoneType' object has no attribute '_sc'
```

The error occurs in GraphFrame's constructor at line 67:

```python
def __init__(self, v, e):
    self._vertices = v
    self._edges = e
    self._spark = SparkSession.getActiveSession()  # Returns None!
    self._sc = self._spark._sc  # Crashes here
```

## Root Cause

This is a **thread-local session visibility issue**, not a true race condition on shared state.

### How Kedro's ThreadRunner Works

Kedro's `ThreadRunner` executes independent pipeline nodes in parallel using Python's `ThreadPoolExecutor`. Each node runs in a separate thread from the pool.

### How PySpark Sessions Work

PySpark maintains the "active session" as a **thread-local variable**. When you call `SparkSession.getActiveSession()`:

1. It checks the current thread's local storage for an active session
2. If the current thread never explicitly created or accessed a session, it returns `None`
3. The actual SparkContext and JVM session still exist - they're just not registered in this thread's local storage

### The Race Condition

```
Main Thread                    Worker Thread (from ThreadPoolExecutor)
─────────────                  ────────────────────────────────────────
SparkSession created ✓
_activeSession set ✓           _activeSession is None (thread-local!)

                               GraphFrame() called
                               getActiveSession() → None
                               self._spark._sc → AttributeError!
```

The session exists globally, but the worker thread doesn't have it registered in its thread-local storage.

## Why It's Intermittent

The failure is intermittent because:

1. **Thread reuse**: ThreadPoolExecutor reuses threads. If a thread previously ran a Spark operation that registered the session, subsequent tasks on that thread succeed.

2. **Execution order**: If `compute_connected_components` happens to run on the main thread or a thread that already accessed Spark, it works.

3. **Timing**: The specific thread assignment depends on which tasks complete first and which threads become available.

## The Fix

```python
# Before creating GraphFrame
if SparkSession.getActiveSession() is None:
    SparkSession.builder.getOrCreate()
```

### Why This Works

1. `getOrCreate()` checks for an existing SparkContext at the JVM level
2. If one exists (it does - created by the main thread), it returns/creates a session using that context
3. This session gets registered in the current thread's local storage
4. Now `getActiveSession()` returns a valid session

### Why This Doesn't Break Parallelism

- No locks or synchronization added
- No sequential execution forced
- The actual Spark operations still run in parallel on the cluster
- Only the Python-side session reference is being established
- `getOrCreate()` is itself thread-safe

## Alternative Solutions Considered

### 1. Switch to SequentialRunner
```python
# In kedro run command
kedro run --runner=SequentialRunner
```
**Rejected**: Loses parallelism benefits, significantly slower pipeline execution.

### 2. Use SparkSession from DataFrame
```python
spark = nodes.sparkSession
SparkSession._activeSession = spark  # Private API
```
**Rejected**: Uses private API (`_activeSession`), could break with PySpark updates.

### 3. Force session in Kedro hook
```python
# In hooks.py
def before_node_run(self, node, catalog, inputs):
    SparkSession.builder.getOrCreate()
```
**Viable but overkill**: Would run for every node, not just GraphFrame nodes.

### 4. The chosen fix (in-function check)
**Accepted**: Minimal, targeted, uses public API only, doesn't affect other code paths.

## Files Changed

- `pipelines/matrix/src/matrix/pipelines/integration/connectivity_metrics.py`
  - Added session availability check in `compute_connected_components_graphframes()`


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
