### PR TITLE
Citrin deficiency unmerged nodes

### DIFF
--- a/pipelines/matrix/conf/base/integration/parameters.yml
+++ b/pipelines/matrix/conf/base/integration/parameters.yml
@@ -145,7 +145,7 @@ integration:
     # latest data, but you are effectively returning whatever you had in the
     # cache. Seehttps://github.com/everycure-org/matrix/pull/1269#issuecomment-2755674916
     preprocessor:
-      _object: matrix.pipelines.batch.pipeline.pass_through
+      _object: matrix.pipelines.integration.nodes.normalize_curie_prefixes
     target_col: normalization_struct
     primary_key: id
 


### PR DESCRIPTION
# Description of the changes

This PR introduces a preprocessing step to normalize CURIE prefixes in node IDs before the main node normalization. Specifically, it converts `HPO:` prefixes to `HP:` to ensure that nodes with semantically identical IDs but different prefix formats (e.g., `HP:0000952` vs `HPO:0000952`) are consistently identified and merged by the NCATS Node Normalizer.

# Fixes / Resolves the following issues:
- ECDATA-954


# Checklist:

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

---
Linear Issue: [ECDATA-954](https://linear.app/everycure/issue/ECDATA-954/investigate-unmerged-nodes-with-same-id-in-citrin-deficiency-subgraph)

<a href="https://cursor.com/background-agent?bcId=bc-37c4b9bf-19ee-4bb5-b606-2393d7ff5d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37c4b9bf-19ee-4bb5-b606-2393d7ff5d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

