### PR TITLE
Fix: dataset name satinization in custom BQ Kedro dataset

### DIFF
--- a/libs/matrix-gcp-datasets/src/matrix_gcp_datasets/gcp.py
+++ b/libs/matrix-gcp-datasets/src/matrix_gcp_datasets/gcp.py
@@ -508,6 +508,7 @@ class GBQTableDataset(KedroGBQTableDataset):
             label_key: Key for the table label to set after saving (optional)
             label_value: Value for the table label to set after saving (optional)
         """
+        dataset = SparkDatasetWithBQExternalTable._sanitize_name(dataset)
         super().__init__(
             project=project,
             dataset=dataset,
@@ -518,7 +519,7 @@ class GBQTableDataset(KedroGBQTableDataset):
             metadata=metadata,
         )
         self.project = project
-        self.dataset = SparkDatasetWithBQExternalTable._sanitize_name(dataset)
+        self.dataset = dataset
         self.table_name = table_name
         self.label_key = label_key
         self.label_value = label_value


### PR DESCRIPTION
# Description of the changes <!-- required! -->

In a previous PR, the dataset name was satinized (`.` changed by `_` to make it acceptable for BQ), but it was done after calling the parent class' init function. The PR corrects this.

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
