### PR TITLE
Publish merged version of disease list

### DIFF
--- a/pipelines/core_entities/src/core_entities/pipelines/disease_list/pipeline.py
+++ b/pipelines/core_entities/src/core_entities/pipelines/disease_list/pipeline.py
@@ -155,8 +155,11 @@ def create_publish_hf_pipeline(**kwargs) -> Pipeline:
     return pipeline(
         [
             node(
-                func=nodes.drop_disease_hf_columns,
-                inputs="primary.release.disease_list_parquet",
+                func=nodes.merge_mondo_and_ec_disease_list,
+                inputs={
+                    "mondo_disease_list": "disease_mondo.prm.disease_list",
+                    "ec_disease_list": "primary.release.disease_list_parquet",
+                },
                 outputs="primary.published.disease_list_hf",
                 name="publish_disease_list_hf",
             ),


### PR DESCRIPTION
The HuggingFace disease list publication previously only included curated diseases. It now left-joins the full Mondo disease list with the EC release list, so all Mondo diseases are present with EC enrichment data (specialties, prevalence, categories, etc.) where available. For overlapping columns, EC values take precedence.

@JacquesVergine the base branch of this PR is my working branch for #2073 

I am only creating this PR for you so you have an easier time isolating that specific feature in your mind - creating the merged disease list prior to publication of HF.
