### PR TITLE
XDATA-312 Update scoring rubric sheet reference in catalog.yml

### DIFF
--- a/pipelines/matrix/conf/base/document_kg/catalog.yml
+++ b/pipelines/matrix/conf/base/document_kg/catalog.yml
@@ -40,7 +40,7 @@ document_kg.raw.matrix_curated_pks@pandas:
 document_kg.raw.matrix_reviews_pks@pandas:
   type: pandas.CSVDataset
   <<: *_layer_raw
-  filepath: "https://docs.google.com/spreadsheets/d/e/2PACX-1vQxpQU80dpW9bo7STfrX7k9Wv70jA_2C4BN6tDceM1LEOfF9YL22OisdmaUPf7Ptw/pub?gid=1308154629&single=true&output=tsv"
+  filepath: "https://docs.google.com/spreadsheets/d/e/2PACX-1vQxpQU80dpW9bo7STfrX7k9Wv70jA_2C4BN6tDceM1LEOfF9YL22OisdmaUPf7Ptw/pub?gid=1421827631&single=true&output=tsv"
   load_args:
     sep: "\t"
 


### PR DESCRIPTION
# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->

Updated document_kg.raw.matrix_reviews_pks@pandas to reference the new scoring rubric tab (GID 1421827631) in the existing Google Sheets published URL.                       


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- [XDATA-312](https://linear.app/everycure/issue/XDATA-312/update-scoring-rubric-sheet-reference-in-catalogyml)


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [x] Added label to PR (e.g. `enhancement` or `bug`)
- [x] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [x] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
