### PR TITLE
Bump pandera constraint to >=0.26.1 in matrix-pandera

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,5 +3,4 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
-    - gha-runner-scale-set
     - ai-platform-dev-gha-runner-scale-set

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,4 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - gha-runner-scale-set
+    - ai-platform-dev-gha-runner-scale-set

--- a/.github/workflows/build_and_upload_image_for_github_runner_set_k8s.yml
+++ b/.github/workflows/build_and_upload_image_for_github_runner_set_k8s.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build-and-push:
     environment: dev
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cleanup_raw_bucket.yml
+++ b/.github/workflows/cleanup_raw_bucket.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   cleanup_raw_bucket:
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     environment: dev
     permissions:
       contents: 'read'

--- a/.github/workflows/core_entities_ci.yaml
+++ b/.github/workflows/core_entities_ci.yaml
@@ -17,7 +17,7 @@ jobs:
   integration-test:
     if: github.event.pull_request.draft == false
     environment: dev
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     defaults:
       run:
         working-directory: pipelines/core_entities

--- a/.github/workflows/core_entities_create_release_pr.yaml
+++ b/.github/workflows/core_entities_create_release_pr.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   create-release-pr:
     environment: dev
-    runs-on: gha-runner-scale-set
+    runs-on: ai-platform-dev-gha-runner-scale-set
     defaults:
       run:
         working-directory: ./pipelines/core_entities

--- a/.github/workflows/core_entities_run_pipeline.yaml
+++ b/.github/workflows/core_entities_run_pipeline.yaml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   setup-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/core_entities_run_pipeline.yaml
+++ b/.github/workflows/core_entities_run_pipeline.yaml
@@ -44,7 +44,7 @@ jobs:
   run-pipeline:
     needs: setup-matrix
     environment: dev
-    runs-on: gha-runner-scale-set
+    runs-on: ai-platform-dev-gha-runner-scale-set
     defaults:
       run:
         working-directory: ./pipelines/core_entities

--- a/.github/workflows/core_entitities_publish_release.yaml
+++ b/.github/workflows/core_entitities_publish_release.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   approved:
     name: Check PR approval or workflow dispatch
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     permissions:
       pull-requests: 'read'
     steps:

--- a/.github/workflows/core_entitities_publish_release.yaml
+++ b/.github/workflows/core_entitities_publish_release.yaml
@@ -46,7 +46,7 @@ jobs:
        github.event.pull_request.merged == true &&
        contains(github.event.pull_request.labels.*.name, 'Core Entities Release'))
     environment: dev
-    runs-on: gha-runner-scale-set
+    runs-on: ai-platform-dev-gha-runner-scale-set
     defaults:
       run:
         working-directory: ./pipelines/core_entities

--- a/.github/workflows/create-post-pr-release.yml
+++ b/.github/workflows/create-post-pr-release.yml
@@ -8,7 +8,7 @@ jobs:
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'Release')
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     name: PR approval
     permissions:
       pull-requests: 'read'
@@ -19,7 +19,7 @@ jobs:
 
   create_release:
     needs: [approved]
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     name: Create release
     permissions:
       contents: 'write'

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   create_release_notes_draft:
     environment: dev
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     name: Create Draft of the Release Notes
     permissions:
       contents: 'write'

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -40,7 +40,7 @@ jobs:
   # https://github.com/orgs/community/discussions/26698
   paths_filter:
     if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ai-platform-dev-gha-runner-scale-set'
     permissions: 
       pull-requests: read
       contents: 'read'
@@ -62,7 +62,7 @@ jobs:
   build_and_deploy:
     environment: dev
     needs: [paths_filter]
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     name: Build Documentation
     permissions:
       contents: 'read'

--- a/.github/workflows/kg-dashboard-deploy.yml
+++ b/.github/workflows/kg-dashboard-deploy.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   build_and_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     name: Build Dashboard
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
     permissions:

--- a/.github/workflows/kg-dashboard-deploy.yml
+++ b/.github/workflows/kg-dashboard-deploy.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   build_and_deploy:
-    runs-on: ai-platform-dev-gha-runner-scale-set
+    runs-on: ubuntu-latest
     name: Build Dashboard
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
     permissions:

--- a/.github/workflows/libs-ci.yml
+++ b/.github/workflows/libs-ci.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   test-libs:
-    runs-on: ubuntu-latest  # Use ubuntu-latest for local testing with act
+    runs-on: ai-platform-dev-gha-runner-scale-set  # Use ai-platform-dev-gha-runner-scale-set for local testing with act
     strategy:
       # NOTE: Matrix here is a github actions concept and is not related to our
       # repository's concept of matrix

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -168,7 +168,7 @@ jobs:
   # we use this check as required in our PRs to ensure that CI runs but only for our paths. 
   matrix_ci_check:
     name: Matrix CI PR Check
-    runs-on:  'gha-runner-scale-set'
+    runs-on:  'ai-platform-dev-gha-runner-scale-set'
     if: always()
     needs: [paths_filter, ci, parallel_commands]
     steps:
@@ -213,7 +213,7 @@ jobs:
   # licenses:
   #   needs: [ci]
   #   # if: github.ref == 'refs/heads/main'
-  #   runs-on: "gha-runner-scale-set"
+  #   runs-on: "ai-platform-dev-gha-runner-scale-set"
   #   defaults:
   #     run:
   #       working-directory: ./pipelines/matrix
@@ -227,7 +227,7 @@ jobs:
     # This condition ensures it runs only if any previous job fails
     # we notify on main branches only
     if: failure() && github.ref == 'refs/heads/main' 
-    runs-on: "gha-runner-scale-set"
+    runs-on: "ai-platform-dev-gha-runner-scale-set"
     steps:
       - name: Post to a Slack channel
         id: slack

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -69,7 +69,7 @@ jobs:
               - .dockerignore
 
   ci:
-    runs-on: 'gha-runner-scale-set'
+    runs-on: ai-platform-dev-gha-runner-scale-set
     needs: [paths_filter]
     if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main')
 
@@ -101,7 +101,7 @@ jobs:
 
   # Run commands in parallel using matrix strategy.
   parallel_commands:
-    runs-on: 'gha-runner-scale-set'
+    runs-on: ai-platform-dev-gha-runner-scale-set
     needs: [paths_filter, ci]
     if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main')
     
@@ -181,7 +181,7 @@ jobs:
   push_image:
     needs: [ci, parallel_commands]
     if: github.ref == 'refs/heads/main'
-    runs-on: 'gha-runner-scale-set'
+    runs-on: ai-platform-dev-gha-runner-scale-set
     environment: dev
     permissions: write-all
     defaults:

--- a/.github/workflows/matrix-ci.yml
+++ b/.github/workflows/matrix-ci.yml
@@ -45,7 +45,7 @@ jobs:
   # https://github.com/orgs/community/discussions/26698
   paths_filter:
     if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ai-platform-dev-gha-runner-scale-set'
     permissions: 
       pull-requests: read
       contents: 'read'

--- a/.github/workflows/moa-ci.yml
+++ b/.github/workflows/moa-ci.yml
@@ -29,7 +29,7 @@ jobs:
   # https://github.com/orgs/community/discussions/26698
   paths_filter:
     if: github.event.pull_request.draft == false || github.ref == 'refs/heads/main'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ai-platform-dev-gha-runner-scale-set'
     permissions: 
       pull-requests: read
       contents: 'read'

--- a/.github/workflows/moa-ci.yml
+++ b/.github/workflows/moa-ci.yml
@@ -67,7 +67,7 @@ jobs:
   push_image:
       needs: [ci]
       if: github.ref == 'refs/heads/main'
-      runs-on: 'gha-runner-scale-set'
+      runs-on: ai-platform-dev-gha-runner-scale-set
       environment: dev
       permissions: write-all
       defaults:

--- a/.github/workflows/moa-ci.yml
+++ b/.github/workflows/moa-ci.yml
@@ -51,7 +51,7 @@ jobs:
               - .github/workflows/moa-ci.yml
 
   ci:
-    runs-on:  'gha-runner-scale-set'
+    runs-on:  'ai-platform-dev-gha-runner-scale-set'
     needs: [paths_filter]
     if: needs.paths_filter.outputs.changed == 'true' && (github.event.pull_request.draft == false || github.ref == 'refs/heads/main')
     defaults:

--- a/.github/workflows/notify-breaking-changes.yml
+++ b/.github/workflows/notify-breaking-changes.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   precommit:
     name: Run Precommit Checks
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ai-platform-dev-gha-runner-scale-set'
     if: github.event.pull_request.draft == false
     
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ai-platform-dev-gha-runner-scale-set
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/submit-kedro-pipeline.yml
+++ b/.github/workflows/submit-kedro-pipeline.yml
@@ -154,7 +154,7 @@ jobs:
     # we notify on main branches only
     needs: submit_data_release_periodically
     if: failure()
-    runs-on: "gha-runner-scale-set"
+    runs-on: "ai-platform-dev-gha-runner-scale-set"
     steps:
       - name: Post to a Slack channel
         id: slack

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,7 +41,7 @@
     "python.defaultInterpreterPath": ".venv/bin/python",
     "python.testing.pytestEnabled": true,
     "makefile.configureOnOpen": false,
-    "editor.acceptSuggestionOnEnter": true,
+    "editor.acceptSuggestionOnEnter": "on",
     "editor.quickSuggestions": {
         "other": false,
         "comments": false,

--- a/docs/src/infrastructure/architecture_decision_records/ci_optimization_self_hosted_runners.md
+++ b/docs/src/infrastructure/architecture_decision_records/ci_optimization_self_hosted_runners.md
@@ -160,13 +160,13 @@ graph TD
 
 ### Configuration Files
 
-- `/infra/argo/app-of-apps/templates/gha-runner-scale-set.yaml` - ArgoCD application
+- `/infra/argo/app-of-apps/templates/ai-platform-dev-gha-runner-scale-set.yaml` - ArgoCD application
 - `/infra/github-runner-image/Dockerfile` - Custom runner image
 - `/.github/workflows/build_and_upload_image_for_github_runner_set_k8s.yml` - Image build pipeline
 
 ### Usage
 
-Replace `runs-on: ubuntu-latest` with `runs-on: gha-runner-scale-set` in GitHub Actions workflows.
+Replace `runs-on: ubuntu-latest` with `runs-on: ai-platform-dev-gha-runner-scale-set` in GitHub Actions workflows.
 
 ## Success Metrics
 

--- a/docs/src/infrastructure/architecture_decision_records/ci_optimization_self_hosted_runners.md
+++ b/docs/src/infrastructure/architecture_decision_records/ci_optimization_self_hosted_runners.md
@@ -166,7 +166,7 @@ graph TD
 
 ### Usage
 
-Replace `runs-on: ubuntu-latest` with `runs-on: ai-platform-dev-gha-runner-scale-set` in GitHub Actions workflows.
+Replace `runs-on: ai-platform-dev-gha-runner-scale-set` with `runs-on: ai-platform-dev-gha-runner-scale-set` in GitHub Actions workflows.
 
 ## Success Metrics
 

--- a/docs/src/infrastructure/github_runner/github_arc_controller.md
+++ b/docs/src/infrastructure/github_runner/github_arc_controller.md
@@ -81,7 +81,7 @@ The ArgoCD applications have been added to app-of-apps. They will be automatical
 ### 3. Verify GitHub Integration
 
 1. Go to https://github.com/everycure-org/matrix/settings/actions/runners
-2. You should see "gha-runner-scale-set" listed as a runner set
+2. You should see "ai-platform-dev-gha-runner-scale-set" listed as a runner set
 3. Initially shows 0 runners (auto-scales on demand)
 
 ## Usage in GitHub Actions
@@ -94,7 +94,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: gha-runner-scale-set # <-- Use this value
+    runs-on: ai-platform-dev-gha-runner-scale-set # <-- Use this value
     steps:
       - uses: actions/checkout@v4
 
@@ -142,17 +142,17 @@ It is advised to refrain from running docker compose and instead rely on nativel
 kubectl get runnerscaleset -n actions-runner-system
 
 # Check individual runners
-kubectl get pods -n actions-runner-system -l app=gha-runner-scale-set
+kubectl get pods -n actions-runner-system -l app=ai-platform-dev-gha-runner-scale-set
 
 # View controller logs
-kubectl logs -n actions-runner-system deployment/gha-runner-scale-set-controller
+kubectl logs -n actions-runner-system deployment/ai-platform-dev-gha-runner-scale-set-controller
 ```
 
 ### GitHub Actions Queue
 
 ```bash
 # Check if runners are being created for queued jobs
-kubectl describe runnerscaleset gha-runner-scale-set -n actions-runner-system
+kubectl describe runnerscaleset ai-platform-dev-gha-runner-scale-set -n actions-runner-system
 ```
 
 ### Common Issues

--- a/docs/src/releases/posts/v0.15.0/post.md
+++ b/docs/src/releases/posts/v0.15.0/post.md
@@ -57,13 +57,11 @@ No breaking changes in this release.
 
 - **ESM2 Embeddings**: Experiment training a classifier for drug-target predictions using embeddings from ESM2 [link to notebook](https://github.com/everycure-org/lab-notebooks/blob/3515b6197bfc1d60e678950a8f12c944912d4296/uab-new-models-for-improved-performance/experiment-december-2025/UAB_Michel_Reproduction_Embeddings_Experiment_Report.ipynb)
 
-- **Patent Scraping Part 4**: The experiment is intended to explore improved text phrase-to-CURIE resolution for Patents [link to notebook](https://github.com/everycure-org/lab-notebooks/blob/c6ad78cd0097f6839f2052adabbbced1b6d91dc1/uab-LLM-patent-scraping/experiment-december-2025/UAB_Patent_Text_Improved_Phrase_to_CURIE_Experiment_Report.ipynb) 
+- **Patent Scraping Part 4**: The experiment is intended to explore improved text phrase-to-CURIE resolution for Patents [link to notebook](https://github.com/everycure-org/lab-notebooks/blob/c6ad78cd0097f6839f2052adabbbced1b6d91dc1/uab-LLM-patent-scraping/experiment-december-2025/UAB_Patent_Text_Improved_Phrase_to_CURIE_Experiment_Report.ipynb)
 
--**SPOKE Experiments**: This captures various experiments with MATRIX pipeline and SPOKE KG to assess its value in drug repurposing. [link to report](https://github.com/everycure-org/lab-notebooks/blob/03773f8c1ad9e20f2eaeafda6d14c3835ed82643/piotr/spoke/spoke_exp.ipynb) 
+-**SPOKE Experiments**: This captures various experiments with MATRIX pipeline and SPOKE KG to assess its value in drug repurposing. [link to report](https://github.com/everycure-org/lab-notebooks/blob/03773f8c1ad9e20f2eaeafda6d14c3835ed82643/piotr/spoke/spoke_exp.ipynb)
 
 - **Final Cross-KG Experiments**: Cross-KG benchmark with MATRIX pipeline and all usable KGs within our system, including aggregated score combining all matrix predictions. [link to report](https://github.com/everycure-org/lab-notebooks/pull/286/changes#diff-6f9510cf6c45eb80444cf45d09a6c12f5ff0bfe335532a50a08b9d49e237aac0)
-
-
 
 No experiment reports in this release.
 
@@ -79,7 +77,7 @@ No experiment reports in this release.
 
 - **Argo Workflow Resource Configuration**: Updated resource allocations and volume mounts in Argo workflow templates. [#2002](https://github.com/everycure-org/matrix/pull/2002), [#2003](https://github.com/everycure-org/matrix/pull/2003)
 
-- **GitHub Actions Runner Scale Set Updates**: Updated gha-runner-scale-set-controller and gha-runner-scale-set to version 0.13.0. [#1991](https://github.com/everycure-org/matrix/pull/1991)
+- **GitHub Actions Runner Scale Set Updates**: Updated ai-platform-dev-gha-runner-scale-set-controller and ai-platform-dev-gha-runner-scale-set to version 0.13.0. [#1991](https://github.com/everycure-org/matrix/pull/1991)
 
 - **Logging Exclusions**: Added severity-based log exclusions (DEFAULT and NOTICE) for hub environments to reduce log noise. [#2050](https://github.com/everycure-org/matrix/pull/2050)
 
@@ -138,4 +136,3 @@ No experiment reports in this release.
 ### Other Changes
 
 - **Core Entities Release PRs**: Multiple release-related PRs for the core entities pipeline (disease_list and drug_list releases). [#2064](https://github.com/everycure-org/matrix/pull/2064), [#2048](https://github.com/everycure-org/matrix/pull/2048), [#2024](https://github.com/everycure-org/matrix/pull/2024), [#2019](https://github.com/everycure-org/matrix/pull/2019)
-

--- a/libs/matrix-pandera/pyproject.toml
+++ b/libs/matrix-pandera/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matrix-pandera"
-version = "0.1.0" 
+version = "0.1.1"
 description = "Cross datatype validation for Matrix platform"
 requires-python = ">=3.11"
 dependencies = [
-    "pandera==0.24.0",
+    "pandera>=0.26.1",
     "pyspark>=3.5.0",
     "pandas",
     "pyarrow",

--- a/libs/matrix-validator/pyproject.toml
+++ b/libs/matrix-validator/pyproject.toml
@@ -9,7 +9,7 @@ description = "Matrix Schema and Data Validation library."
 requires-python = ">=3.11"
 dependencies = [
     "polars-lts-cpu>=1.23.0",
-    "pandera==0.24.0",
+    "pandera>=0.26.1",
     "pyspark>=3.5.0",
     "pandas",
     "pyarrow",

--- a/pipelines/matrix/pyproject.toml
+++ b/pipelines/matrix/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "numpy==1.24.4", # This was pinned during refit refactor; fabricator pipeline fails on 1.26.4
     "openai",
     "openpyxl",
-    "pandera==0.24.0",
+    "pandera>=0.26.1",
     "pandas>=2.1.1", #due to pandera requiring this or higher
     "polars-lts-cpu>=1.30.0",
     "proto-plus==1.24.0.dev1", # Temp. fix for the gcloud cli


### PR DESCRIPTION
## Summary
- Bumps `matrix-pandera` version from `0.1.0` to `0.1.1`
- Relaxes pandera pin from `==0.24.0` to `>=0.26.1` to resolve conflict with `everycure-datasets>=0.2.122` which requires `pandera>=0.26.1`

## Test plan
- [ ] Verify `matrix-pandera` installs correctly with `pandera>=0.26.1`
- [ ] Verify orchard pipeline lock resolves without pandera conflict after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)