### PR TITLE
Nelson/ops 364 grant storage access to alan from scripps

### DIFF
--- a/infra/deployments/hub/dev/storage.tf
+++ b/infra/deployments/hub/dev/storage.tf
@@ -133,3 +133,14 @@ resource "google_storage_bucket_iam_member" "matrix_subcontractors_bucket_reader
   role   = "roles/storage.legacyBucketReader"
   member = "group:matrix-subcontractors@everycure.org"
 }
+# Temporary scoped access for Alan Hueb (Scripps) to v0.8.2 release data
+resource "google_storage_bucket_iam_member" "alan_hueb_release_viewer" {
+  bucket = "mtrx-us-central1-hub-dev-storage"
+  role   = "roles/storage.objectViewer"
+  member = "user:alan@hueb.org"
+
+  condition {
+    title      = "only_v0_8_2_release"
+    expression = "resource.name.startsWith('projects/_/buckets/mtrx-us-central1-hub-dev-storage/objects/kedro/data/releases/v0.8.2')"
+  }
+}

--- a/infra/deployments/hub/dev/storage.tf
+++ b/infra/deployments/hub/dev/storage.tf
@@ -133,6 +133,7 @@ resource "google_storage_bucket_iam_member" "matrix_subcontractors_bucket_reader
   role   = "roles/storage.legacyBucketReader"
   member = "group:matrix-subcontractors@everycure.org"
 }
+
 # Temporary scoped access for Alan Hueb (Scripps) to v0.8.2 release data
 resource "google_storage_bucket_iam_member" "alan_hueb_release_viewer" {
   bucket = "mtrx-us-central1-hub-dev-storage"
@@ -143,4 +144,11 @@ resource "google_storage_bucket_iam_member" "alan_hueb_release_viewer" {
     title      = "only_v0_8_2_release"
     expression = "resource.name.startsWith('projects/_/buckets/mtrx-us-central1-hub-dev-storage/objects/kedro/data/releases/v0.8.2')"
   }
+}
+
+# Bucket-level read access for Alan (needed for gsutil/SDK navigation; no condition possible on bucket-level perms)
+resource "google_storage_bucket_iam_member" "alan_hueb_bucket_reader" {
+  bucket = "mtrx-us-central1-hub-dev-storage"
+  role   = "roles/storage.legacyBucketReader"
+  member = "user:alan@hueb.org"
 }


### PR DESCRIPTION
This pull request introduces temporary and scoped access controls for a specific user and updates a subproject reference. The main focus is on providing Alan Hueb (Scripps) with access to release data in the development storage bucket.

# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
