### PR TITLE
Change Neo4j replicaSets to 0 but keep disk

### DIFF
--- a/infra/argo/app-of-apps/templates/neo4j.yaml
+++ b/infra/argo/app-of-apps/templates/neo4j.yaml
@@ -24,4 +24,11 @@ spec:
     syncOptions:     # Sync options which modifies sync behavior
     - CreateNamespace=true # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.
     automated: 
-      prune: true
+      prune: true  # Ignore replica count so we can scale the StatefulSet to 0 (stop the pod, keep the PVC/disk)
+  # without Argo CD reverting it back to the chart's hardcoded replicas: 1 on the next sync.
+  ignoreDifferences:
+    - group: apps
+      kind: StatefulSet
+      name: neo4j
+      jsonPointers:
+        - /spec/replicas


### PR DESCRIPTION
Ignore replicas set size in ArgoCD so we could manually scale down Neo4j to 0 while keeping the disk in case we want to revert

After merging we will run: `kubectl -n neo4j scale statefulset neo4j --replicas=0` on the Matrix Hub Dev Cluster.

Incase we want to bring it up, we do: `kubectl -n neo4j scale statefulset neo4j --replicas=1`

# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
