### PR TITLE
Remove BuildKit cache mount on /root/.ivy2/cache in Dockerfile

### DIFF
--- a/pipelines/matrix/Dockerfile
+++ b/pipelines/matrix/Dockerfile
@@ -31,9 +31,13 @@ RUN --mount=type=cache,target=/root/.cache uv sync --frozen  --no-install-worksp
 ENV PATH=/matrix/.venv/bin:$PATH
 
 # Cache spark drivers as part of image
+# NOTE: no BuildKit cache mount on /root/.ivy2/cache here - that is the exact directory
+# Spark/Ivy reads from at runtime, so a cache mount would discard the resolved jars
+# from the final image, forcing every container to re-resolve them from Maven Central
+# at startup (and fail if there is no network access at that moment).
 COPY pipelines/matrix/conf/base/spark.yml ./conf/base/spark.yml
 COPY pipelines/matrix/scripts/maven-deps.py ./maven-deps.py
-RUN --mount=type=cache,target=/root/.ivy2/cache python maven-deps.py
+RUN python maven-deps.py
 
 # We copy in the libs folder here and run a full sync which leads to only the delta
 # being installed which are... just the libs. the matrix pipeline 


### PR DESCRIPTION
Spark/Ivy reads jars from this exact directory at runtime, so caching it would discard resolved jars from the final image, forcing containers to re-resolve them from Maven Central at startup and fail without network access.

# Description of the changes <!-- required! -->

<!-- Briefly describe the changes you have made. This helps the reviewer understand the changes. -->


## Fixes / Resolves the following issues:
<!-- add the issues here. -->
- 


# Checklist:

<!-- Please remove any items from this checklist that are not applicable to this PR. -->

- [ ] Added label to PR (e.g. `enhancement` or `bug`)
- [ ] Ensured the PR is named descriptively. FYI: This name is used as part of our changelog & release notes.
- [ ] Looked at the diff on github to make sure no unwanted files have been committed. 
- [ ] Made corresponding changes to the documentation
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] If breaking changes occur or you need everyone to run a command locally after
    pulling in latest main, uncomment the below "Merge Notification" section and
    describe steps necessary for people
- [ ] Ran on sample data using `kedro run -e sample -p test_sample` (see [sample environment guide](https://docs.dev.everycure.org/onboarding/sample_environment/))

<!-- uncomment the below section if you want a notice to be sent to our slack community upon
a successful merge of the PR -->

<!--
## Merge Notification

-->
